### PR TITLE
feat: unify put and put_with_size into single put API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,37 +11,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### **Unified `put` API**
 
-The `put` method signature has changed for all cache algorithms. The separate `put_with_size()` method has been removed in favor of a unified API:
+The `put` method signature has changed for all cache algorithms. The `size` parameter is now required (no longer `Option<u64>`):
 
 **Before (0.3.x):**
 ```rust
-cache.put(key, value);                    // Entry-count mode
-cache.put_with_size(key, value, size);    // Size-based mode
+cache.put(key, value, None);              // Entry-count mode (size defaults to 1)
+cache.put(key, value, Some(1024));        // Size-based mode
 ```
 
 **After:**
 ```rust
-cache.put(key, value, None);              // Entry-count mode (size defaults to 1)
-cache.put(key, value, Some(1024));        // Size-based mode
+cache.put(key, value, 1);              // Entry-count mode
+cache.put(key, value, 1024);           // Size-based mode
 ```
 
 #### **Migration Guide**
 
 | Old API | New API |
 |---------|---------|
-| `cache.put(key, value)` | `cache.put(key, value, None)` |
-| `cache.put_with_size(key, value, size)` | `cache.put(key, value, Some(size))` |
+| `cache.put(key, value, None)` | `cache.put(key, value, 1)` |
+| `cache.put(key, value, Some(size))` | `cache.put(key, value, size)` |
 
 This applies to all algorithms (LRU, LFU, LFUDA, SLRU, GDSF) and their concurrent variants.
 
 ### Changed
 
-- **GDSF**: The `size` parameter is now `Option<u64>` instead of required `u64`, defaulting to `1` when `None`
-- **Internal**: Removed `estimate_object_size()` helper functions as they are no longer needed
+- **API**: The `size` parameter is now required `u64` instead of `Option<u64>`
+- **Documentation**: Updated all examples to use the new required size parameter
+
+### Added
+
+- **`SIZE_UNIT` constant**: Use `cache_rs::SIZE_UNIT` (= 1) for entry-count mode caching
 
 ### Removed
 
-- `put_with_size()` method from all cache implementations
+- Support for `None` as a default size (use `1` or `SIZE_UNIT` explicitly)
 - Separate `put_with_size_stats` tracking in cache-simulator (merged into `put_stats`)
 
 ## [0.3.1] - 2026-02-03
@@ -69,9 +73,9 @@ All caches previously supported multiple initialization methods which have now b
 - `new()` → Use `init(config, None)`
 - `with_limits()` → Use `init(config, None)`
 - `with_max_size()` → Use `init(config, None)`
-- `with_hasher()` → Use `init(config, Some(hasher))`
-- `with_hasher_and_size()` → Use `init(config, Some(hasher))`
-- `init_with_hasher()` → Use `init(config, Some(hasher))`
+- `with_hasher()` → Use `init(config, hasher)`
+- `with_hasher_and_size()` → Use `init(config, hasher)`
+- `init_with_hasher()` → Use `init(config, hasher)`
 
 #### **Migration Guide**
 
@@ -96,7 +100,7 @@ let config = LruCacheConfig {
 let cache = LruCache::init(config, None);
 
 // With custom hasher
-let cache = LruCache::init(config, Some(my_hasher));
+let cache = LruCache::init(config, my_hasher);
 
 // SLRU example
 let config = SlruCacheConfig {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ⚠️ BREAKING CHANGES
+
+#### **Unified `put` API**
+
+The `put` method signature has changed for all cache algorithms. The separate `put_with_size()` method has been removed in favor of a unified API:
+
+**Before (0.3.x):**
+```rust
+cache.put(key, value);                    // Entry-count mode
+cache.put_with_size(key, value, size);    // Size-based mode
+```
+
+**After:**
+```rust
+cache.put(key, value, None);              // Entry-count mode (size defaults to 1)
+cache.put(key, value, Some(1024));        // Size-based mode
+```
+
+#### **Migration Guide**
+
+| Old API | New API |
+|---------|---------|
+| `cache.put(key, value)` | `cache.put(key, value, None)` |
+| `cache.put_with_size(key, value, size)` | `cache.put(key, value, Some(size))` |
+
+This applies to all algorithms (LRU, LFU, LFUDA, SLRU, GDSF) and their concurrent variants.
+
+### Changed
+
+- **GDSF**: The `size` parameter is now `Option<u64>` instead of required `u64`, defaulting to `1` when `None`
+- **Internal**: Removed `estimate_object_size()` helper functions as they are no longer needed
+
+### Removed
+
+- `put_with_size()` method from all cache implementations
+- Separate `put_with_size_stats` tracking in cache-simulator (merged into `put_stats`)
+
 ## [0.3.1] - 2026-02-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ All cache types support these core operations:
 
 | Method | Description |
 |--------|-------------|
-| `put(key, value)` | Insert or update an entry. Returns evicted entry if capacity exceeded. |
-| `put(key, value, Some(size))` | Insert with explicit size for size-limited caches. |
+| `put(key, value, size)` | Insert or update an entry with explicit size. Returns evicted entry if capacity exceeded. Use `1` for count-based caching. |
 | `get(&key)` | Retrieve a reference to the value. Updates access metadata (e.g., moves to front in LRU). |
 | `get_mut(&key)` | Retrieve a mutable reference. Updates access metadata. |
 | `remove(&key)` | Remove and return an entry. |
@@ -90,8 +89,8 @@ let config = LruCacheConfig {
 let mut cache = LruCache::init(config, None);
 
 // Insert entries
-cache.put("user:1001", "Alice", None);
-cache.put("user:1002", "Bob", None);
+cache.put("user:1001", "Alice", 1);
+cache.put("user:1002", "Bob", 1);
 
 // Retrieve (updates LRU position)
 assert_eq!(cache.get(&"user:1001"), Some(&"Alice"));
@@ -145,7 +144,7 @@ This dual-limit approach gives you precise control:
 
 ### Specifying Entry Size
 
-By default, `put(key, value)` treats each entry as having size `1`. For size-aware caching, use `put(key, value, Some(size))`:
+The `put(key, value, size)` method always requires a size parameter. For count-based caching (where you just want to limit the number of entries), use `1` for the size:
 
 ```rust
 use cache_rs::LruCache;
@@ -160,10 +159,10 @@ let mut cache: LruCache<&str, Vec<u8>> = LruCache::init(config, None);
 
 // Size-aware insertion: this blob consumes 5KB of the 10MB budget
 let blob = vec![0u8; 5000];
-cache.put("large-blob", blob, Some(5000));
+cache.put("large-blob", blob, 5000);
 ```
 
-**Note**: For GDSF caches, `put(key, value, size)` always requires the size parameter since size is integral to the eviction algorithm.
+**Note**: All cache types now use the same signature: `put(key, value, size)`. For count-based caching, pass `1` as the size.
 
 ### Sizing Strategies
 
@@ -204,7 +203,7 @@ let mut cache = LruCache::init(config, None);
 // Track actual sizes when inserting
 let image_data = load_image("photo.jpg");
 let image_size = image_data.len() as u64;
-cache.put("photo.jpg", image_data, Some(image_size));
+cache.put("photo.jpg", image_data, image_size);
 ```
 
 **Use case**: CDN caches, file caches, response caches where objects vary significantly in size.
@@ -249,18 +248,18 @@ let config = LruCacheConfig {
 let mut cache: LruCache<&str, &str> = LruCache::init(config, None);
 
 // Insert 3 entries, each with size 30 bytes
-cache.put("a", "value_a", Some(30));  // entries=1, size=30
-cache.put("b", "value_b", Some(30));  // entries=2, size=60
-cache.put("c", "value_c", Some(30));  // entries=3, size=90
+cache.put("a", "value_a", 30);  // entries=1, size=30
+cache.put("b", "value_b", 30);  // entries=2, size=60
+cache.put("c", "value_c", 30);  // entries=3, size=90
 
 // Case 1: Capacity-triggered eviction
 // Adding "d" would exceed capacity (3 entries), so "a" is evicted
-cache.put("d", "value_d", Some(30));  // evicts "a", entries=3, size=90
+cache.put("d", "value_d", 30);  // evicts "a", entries=3, size=90
 
 // Case 2: Size-triggered eviction
 // Adding a 50-byte entry would exceed max_size (90 + 50 > 100)
 // Multiple entries may be evicted to make room
-cache.put("big", "large_value", Some(50));  // evicts until size fits
+cache.put("big", "large_value", 50);  // evicts until size fits
 ```
 
 For concurrent caches, `capacity` and `max_size` apply to the **entire cache** (distributed across all segments), not per-segment
@@ -401,8 +400,8 @@ let config = GdsfCacheConfig {
 let mut cache: GdsfCache<&str, Vec<u8>> = GdsfCache::init(config, None);
 
 // put() requires size parameter
-cache.put("small.txt", "content", Some(1024));        // 1 KB
-cache.put("large.bin", "content", Some(10_000_000));  // 10 MB
+cache.put("small.txt", "content", 1024);        // 1 KB
+cache.put("large.bin", "content", 10_000_000);  // 10 MB
 ```
 
 ---
@@ -460,7 +459,7 @@ let handles: Vec<_> = (0..8).map(|i| {
     thread::spawn(move || {
         for j in 0..1000 {
             let key = format!("thread{}-key{}", i, j);
-            cache.put(key.clone(), i * 1000 + j, None);
+            cache.put(key.clone(), i * 1000 + j, 1);
             cache.get(&key);
         }
     })
@@ -488,7 +487,7 @@ let config = ConcurrentCacheConfig {
     segments: 16,
 };
 let cache: ConcurrentLruCache<String, Vec<u8>> = ConcurrentLruCache::init(config, None);
-cache.put("data".to_string(), vec![1u8; 1024], None);
+cache.put("data".to_string(), vec![1u8; 1024], 1);
 
 // Process in-place without cloning
 let sum: Option<u8> = cache.get_with(&"data".to_string(), |bytes| {
@@ -556,7 +555,7 @@ impl TieredCache {
         if let Some((_, evicted)) = self.index.put(
             key.to_string(),
             DiskEntry { path: path.clone(), size: content.len() as u64 },
-            None,
+            content.len() as u64,
         ) {
             // Clean up evicted file from disk
             let _ = fs::remove_file(&evicted.path);
@@ -603,7 +602,7 @@ let config = LruCacheConfig {
     max_size: u64::MAX,
 };
 let mut cache: LruCache<String, &str> = LruCache::init(config, None);
-cache.put(String::from("key"), "value", None);
+cache.put(String::from("key"), "value", 1);
 ```
 
 ### Feature Flags

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All cache types support these core operations:
 | Method | Description |
 |--------|-------------|
 | `put(key, value)` | Insert or update an entry. Returns evicted entry if capacity exceeded. |
-| `put_with_size(key, value, size)` | Insert with explicit size for size-limited caches. |
+| `put(key, value, Some(size))` | Insert with explicit size for size-limited caches. |
 | `get(&key)` | Retrieve a reference to the value. Updates access metadata (e.g., moves to front in LRU). |
 | `get_mut(&key)` | Retrieve a mutable reference. Updates access metadata. |
 | `remove(&key)` | Remove and return an entry. |
@@ -90,8 +90,8 @@ let config = LruCacheConfig {
 let mut cache = LruCache::init(config, None);
 
 // Insert entries
-cache.put("user:1001", "Alice");
-cache.put("user:1002", "Bob");
+cache.put("user:1001", "Alice", None);
+cache.put("user:1002", "Bob", None);
 
 // Retrieve (updates LRU position)
 assert_eq!(cache.get(&"user:1001"), Some(&"Alice"));
@@ -145,7 +145,7 @@ This dual-limit approach gives you precise control:
 
 ### Specifying Entry Size
 
-By default, `put(key, value)` treats each entry as having size `1`. For size-aware caching, use `put_with_size(key, value, size)`:
+By default, `put(key, value)` treats each entry as having size `1`. For size-aware caching, use `put(key, value, Some(size))`:
 
 ```rust
 use cache_rs::LruCache;
@@ -160,7 +160,7 @@ let mut cache: LruCache<&str, Vec<u8>> = LruCache::init(config, None);
 
 // Size-aware insertion: this blob consumes 5KB of the 10MB budget
 let blob = vec![0u8; 5000];
-cache.put_with_size("large-blob", blob, 5000);
+cache.put("large-blob", blob, Some(5000));
 ```
 
 **Note**: For GDSF caches, `put(key, value, size)` always requires the size parameter since size is integral to the eviction algorithm.
@@ -204,7 +204,7 @@ let mut cache = LruCache::init(config, None);
 // Track actual sizes when inserting
 let image_data = load_image("photo.jpg");
 let image_size = image_data.len() as u64;
-cache.put_with_size("photo.jpg", image_data, image_size);
+cache.put("photo.jpg", image_data, Some(image_size));
 ```
 
 **Use case**: CDN caches, file caches, response caches where objects vary significantly in size.
@@ -249,18 +249,18 @@ let config = LruCacheConfig {
 let mut cache: LruCache<&str, &str> = LruCache::init(config, None);
 
 // Insert 3 entries, each with size 30 bytes
-cache.put_with_size("a", "value_a", 30);  // entries=1, size=30
-cache.put_with_size("b", "value_b", 30);  // entries=2, size=60
-cache.put_with_size("c", "value_c", 30);  // entries=3, size=90
+cache.put("a", "value_a", Some(30));  // entries=1, size=30
+cache.put("b", "value_b", Some(30));  // entries=2, size=60
+cache.put("c", "value_c", Some(30));  // entries=3, size=90
 
 // Case 1: Capacity-triggered eviction
 // Adding "d" would exceed capacity (3 entries), so "a" is evicted
-cache.put_with_size("d", "value_d", 30);  // evicts "a", entries=3, size=90
+cache.put("d", "value_d", Some(30));  // evicts "a", entries=3, size=90
 
 // Case 2: Size-triggered eviction
 // Adding a 50-byte entry would exceed max_size (90 + 50 > 100)
 // Multiple entries may be evicted to make room
-cache.put_with_size("big", "large_value", 50);  // evicts until size fits
+cache.put("big", "large_value", Some(50));  // evicts until size fits
 ```
 
 For concurrent caches, `capacity` and `max_size` apply to the **entire cache** (distributed across all segments), not per-segment
@@ -401,8 +401,8 @@ let config = GdsfCacheConfig {
 let mut cache: GdsfCache<&str, Vec<u8>> = GdsfCache::init(config, None);
 
 // put() requires size parameter
-cache.put("small.txt", "content", 1024);        // 1 KB
-cache.put("large.bin", "content", 10_000_000);  // 10 MB
+cache.put("small.txt", "content", Some(1024));        // 1 KB
+cache.put("large.bin", "content", Some(10_000_000));  // 10 MB
 ```
 
 ---
@@ -460,7 +460,7 @@ let handles: Vec<_> = (0..8).map(|i| {
     thread::spawn(move || {
         for j in 0..1000 {
             let key = format!("thread{}-key{}", i, j);
-            cache.put(key.clone(), i * 1000 + j);
+            cache.put(key.clone(), i * 1000 + j, None);
             cache.get(&key);
         }
     })
@@ -488,7 +488,7 @@ let config = ConcurrentCacheConfig {
     segments: 16,
 };
 let cache: ConcurrentLruCache<String, Vec<u8>> = ConcurrentLruCache::init(config, None);
-cache.put("data".to_string(), vec![1u8; 1024]);
+cache.put("data".to_string(), vec![1u8; 1024], None);
 
 // Process in-place without cloning
 let sum: Option<u8> = cache.get_with(&"data".to_string(), |bytes| {
@@ -555,7 +555,8 @@ impl TieredCache {
         // Update index (may evict old entry)
         if let Some((_, evicted)) = self.index.put(
             key.to_string(),
-            DiskEntry { path: path.clone(), size: content.len() as u64 }
+            DiskEntry { path: path.clone(), size: content.len() as u64 },
+            None,
         ) {
             // Clean up evicted file from disk
             let _ = fs::remove_file(&evicted.path);
@@ -602,7 +603,7 @@ let config = LruCacheConfig {
     max_size: u64::MAX,
 };
 let mut cache: LruCache<String, &str> = LruCache::init(config, None);
-cache.put(String::from("key"), "value");
+cache.put(String::from("key"), "value", None);
 ```
 
 ### Feature Flags

--- a/benches/cache_benchmarks.rs
+++ b/benches/cache_benchmarks.rs
@@ -120,7 +120,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx, None));
+                    black_box(cache.put(idx, idx, 1));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -136,7 +136,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx, None));
+                    black_box(cache.put(idx, idx, 1));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -152,7 +152,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx, None));
+                    black_box(cache.put(idx, idx, 1));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -168,7 +168,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx, None));
+                    black_box(cache.put(idx, idx, 1));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -185,7 +185,7 @@ fn benchmark_caches(c: &mut Criterion) {
                 if idx % 4 == 0 {
                     // 25% puts - Use idx as size too, smaller items more likely due to Zipf
                     let size = ((idx % 100) + 1) as u64; // Size between 1-100
-                    black_box(cache.put(idx, idx, Some(size)));
+                    black_box(cache.put(idx, idx, size));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));

--- a/benches/cache_benchmarks.rs
+++ b/benches/cache_benchmarks.rs
@@ -120,7 +120,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx));
+                    black_box(cache.put(idx, idx, None));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -136,7 +136,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx));
+                    black_box(cache.put(idx, idx, None));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -152,7 +152,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx));
+                    black_box(cache.put(idx, idx, None));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -168,7 +168,7 @@ fn benchmark_caches(c: &mut Criterion) {
             for &idx in &samples {
                 if idx % 4 == 0 {
                     // 25% puts
-                    black_box(cache.put(idx, idx));
+                    black_box(cache.put(idx, idx, None));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));
@@ -185,7 +185,7 @@ fn benchmark_caches(c: &mut Criterion) {
                 if idx % 4 == 0 {
                     // 25% puts - Use idx as size too, smaller items more likely due to Zipf
                     let size = ((idx % 100) + 1) as u64; // Size between 1-100
-                    black_box(cache.put(idx, idx, size));
+                    black_box(cache.put(idx, idx, Some(size)));
                 } else {
                     // 75% gets
                     black_box(cache.get(&idx));

--- a/benches/concurrent_benchmarks.rs
+++ b/benches/concurrent_benchmarks.rs
@@ -106,11 +106,11 @@ fn concurrent_reads(c: &mut Criterion) {
 
     // Fill caches
     for i in 0..CACHE_SIZE {
-        lru_cache.put(i, i, None);
-        slru_cache.put(i, i, None);
-        lfu_cache.put(i, i, None);
-        lfuda_cache.put(i, i, None);
-        gdsf_cache.put(i, i, Some(((i % 10) + 1) as u64));
+        lru_cache.put(i, i, 1);
+        slru_cache.put(i, i, 1);
+        lfu_cache.put(i, i, 1);
+        lfuda_cache.put(i, i, 1);
+        gdsf_cache.put(i, i, ((i % 10) + 1) as u64);
     }
 
     group.bench_function("LRU", |b| {
@@ -218,7 +218,7 @@ fn concurrent_mixed(c: &mut Criterion) {
             Arc::new(ConcurrentLruCache::init(lru_config(CACHE_SIZE), None));
         // Pre-populate
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -232,7 +232,7 @@ fn concurrent_mixed(c: &mut Criterion) {
             None,
         ));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -244,7 +244,7 @@ fn concurrent_mixed(c: &mut Criterion) {
         let cache: Arc<ConcurrentLfuCache<usize, usize>> =
             Arc::new(ConcurrentLfuCache::init(lfu_config(CACHE_SIZE), None));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -256,7 +256,7 @@ fn concurrent_mixed(c: &mut Criterion) {
         let cache: Arc<ConcurrentLfudaCache<usize, usize>> =
             Arc::new(ConcurrentLfudaCache::init(lfuda_config(CACHE_SIZE), None));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -270,7 +270,7 @@ fn concurrent_mixed(c: &mut Criterion) {
             None,
         ));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, Some(((i % 10) + 1) as u64));
+            cache.put(i, i, ((i % 10) + 1) as u64);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -296,7 +296,7 @@ fn segment_count_comparison(c: &mut Criterion) {
                 );
                 // Pre-populate
                 for i in 0..CACHE_SIZE {
-                    cache.put(i, i, None);
+                    cache.put(i, i, 1);
                 }
                 b.iter(|| {
                     let cache = Arc::clone(&cache);
@@ -324,7 +324,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value, None);
+        self.put(key, value, 1);
     }
 }
 
@@ -337,7 +337,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value, None);
+        self.put(key, value, 1);
     }
 }
 
@@ -350,7 +350,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value, None);
+        self.put(key, value, 1);
     }
 }
 
@@ -363,7 +363,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value, None);
+        self.put(key, value, 1);
     }
 }
 
@@ -466,7 +466,7 @@ fn run_concurrent_writes_gdsf(
             for i in 0..ops_per_thread {
                 let key = t * ops_per_thread + i;
                 let size = ((key % 10) + 1) as u64;
-                cache.put(key, key, Some(size));
+                cache.put(key, key, size);
             }
         }));
     }
@@ -488,7 +488,7 @@ fn run_concurrent_mixed_gdsf(
                 let key = (t * ops_per_thread + i) % CACHE_SIZE;
                 if i % 5 == 0 {
                     let size = ((key % 10) + 1) as u64;
-                    cache.put(key, key, Some(size));
+                    cache.put(key, key, size);
                 } else {
                     black_box(cache.get(&key));
                 }

--- a/benches/concurrent_benchmarks.rs
+++ b/benches/concurrent_benchmarks.rs
@@ -106,11 +106,11 @@ fn concurrent_reads(c: &mut Criterion) {
 
     // Fill caches
     for i in 0..CACHE_SIZE {
-        lru_cache.put(i, i);
-        slru_cache.put(i, i);
-        lfu_cache.put(i, i);
-        lfuda_cache.put(i, i);
-        gdsf_cache.put(i, i, ((i % 10) + 1) as u64);
+        lru_cache.put(i, i, None);
+        slru_cache.put(i, i, None);
+        lfu_cache.put(i, i, None);
+        lfuda_cache.put(i, i, None);
+        gdsf_cache.put(i, i, Some(((i % 10) + 1) as u64));
     }
 
     group.bench_function("LRU", |b| {
@@ -218,7 +218,7 @@ fn concurrent_mixed(c: &mut Criterion) {
             Arc::new(ConcurrentLruCache::init(lru_config(CACHE_SIZE), None));
         // Pre-populate
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -232,7 +232,7 @@ fn concurrent_mixed(c: &mut Criterion) {
             None,
         ));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -244,7 +244,7 @@ fn concurrent_mixed(c: &mut Criterion) {
         let cache: Arc<ConcurrentLfuCache<usize, usize>> =
             Arc::new(ConcurrentLfuCache::init(lfu_config(CACHE_SIZE), None));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -256,7 +256,7 @@ fn concurrent_mixed(c: &mut Criterion) {
         let cache: Arc<ConcurrentLfudaCache<usize, usize>> =
             Arc::new(ConcurrentLfudaCache::init(lfuda_config(CACHE_SIZE), None));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -270,7 +270,7 @@ fn concurrent_mixed(c: &mut Criterion) {
             None,
         ));
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, ((i % 10) + 1) as u64);
+            cache.put(i, i, Some(((i % 10) + 1) as u64));
         }
         b.iter(|| {
             let cache = Arc::clone(&cache);
@@ -296,7 +296,7 @@ fn segment_count_comparison(c: &mut Criterion) {
                 );
                 // Pre-populate
                 for i in 0..CACHE_SIZE {
-                    cache.put(i, i);
+                    cache.put(i, i, None);
                 }
                 b.iter(|| {
                     let cache = Arc::clone(&cache);
@@ -324,7 +324,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value);
+        self.put(key, value, None);
     }
 }
 
@@ -337,7 +337,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value);
+        self.put(key, value, None);
     }
 }
 
@@ -350,7 +350,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value);
+        self.put(key, value, None);
     }
 }
 
@@ -363,7 +363,7 @@ where
         self.get(key)
     }
     fn cache_put(&self, key: K, value: V) {
-        self.put(key, value);
+        self.put(key, value, None);
     }
 }
 
@@ -466,7 +466,7 @@ fn run_concurrent_writes_gdsf(
             for i in 0..ops_per_thread {
                 let key = t * ops_per_thread + i;
                 let size = ((key % 10) + 1) as u64;
-                cache.put(key, key, size);
+                cache.put(key, key, Some(size));
             }
         }));
     }
@@ -488,7 +488,7 @@ fn run_concurrent_mixed_gdsf(
                 let key = (t * ops_per_thread + i) % CACHE_SIZE;
                 if i % 5 == 0 {
                     let size = ((key % 10) + 1) as u64;
-                    cache.put(key, key, size);
+                    cache.put(key, key, Some(size));
                 } else {
                     black_box(cache.get(&key));
                 }

--- a/benches/criterion_benchmarks.rs
+++ b/benches/criterion_benchmarks.rs
@@ -60,7 +60,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_lru(CACHE_SIZE);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
 
         group.bench_function("LRU get hit", |b| {
@@ -82,7 +82,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("LRU put existing", |b| {
             b.iter(|| {
                 for i in 0..100 {
-                    black_box(cache.put(i % CACHE_SIZE, i, None));
+                    black_box(cache.put(i % CACHE_SIZE, i, 1));
                 }
             });
         });
@@ -92,7 +92,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_lfu(CACHE_SIZE);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
 
         group.bench_function("LFU get hit", |b| {
@@ -108,7 +108,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_lfuda(CACHE_SIZE);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
 
         group.bench_function("LFUDA get hit", |b| {
@@ -124,7 +124,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_slru(CACHE_SIZE, CACHE_SIZE / 2);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, None);
+            cache.put(i, i, 1);
         }
 
         group.bench_function("SLRU get hit", |b| {
@@ -140,7 +140,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_gdsf(CACHE_SIZE * 10);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, Some(((i % 10) + 1) as u64)); // Size between 1-10, cast to u64
+            cache.put(i, i, ((i % 10) + 1) as u64); // Size between 1-10, cast to u64
         }
 
         group.bench_function("GDSF get hit", |b| {

--- a/benches/criterion_benchmarks.rs
+++ b/benches/criterion_benchmarks.rs
@@ -60,7 +60,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_lru(CACHE_SIZE);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
 
         group.bench_function("LRU get hit", |b| {
@@ -82,7 +82,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("LRU put existing", |b| {
             b.iter(|| {
                 for i in 0..100 {
-                    black_box(cache.put(i % CACHE_SIZE, i));
+                    black_box(cache.put(i % CACHE_SIZE, i, None));
                 }
             });
         });
@@ -92,7 +92,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_lfu(CACHE_SIZE);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
 
         group.bench_function("LFU get hit", |b| {
@@ -108,7 +108,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_lfuda(CACHE_SIZE);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
 
         group.bench_function("LFUDA get hit", |b| {
@@ -124,7 +124,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_slru(CACHE_SIZE, CACHE_SIZE / 2);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i);
+            cache.put(i, i, None);
         }
 
         group.bench_function("SLRU get hit", |b| {
@@ -140,7 +140,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut cache = make_gdsf(CACHE_SIZE * 10);
         for i in 0..CACHE_SIZE {
-            cache.put(i, i, ((i % 10) + 1) as u64); // Size between 1-10, cast to u64
+            cache.put(i, i, Some(((i % 10) + 1) as u64)); // Size between 1-10, cast to u64
         }
 
         group.bench_function("GDSF get hit", |b| {

--- a/cache-simulator/src/models.rs
+++ b/cache-simulator/src/models.rs
@@ -231,10 +231,8 @@ pub struct LatencyStats {
     pub count: u64,
     /// Get operation stats
     pub get_stats: OpLatencyStats,
-    /// Put operation stats (regular put without size)
+    /// Put operation stats (all put operations, with or without size)
     pub put_stats: OpLatencyStats,
-    /// Put with size operation stats
-    pub put_with_size_stats: OpLatencyStats,
 }
 
 /// Latency percentiles
@@ -315,7 +313,7 @@ pub struct CsvResultRow {
     pub final_storage_bytes: usize,
     pub estimated_memory_bytes: usize,
     // Combined stats
-    /// Total operations (get + put + put_with_size)
+    /// Total operations (get + put)
     pub total_ops: u64,
     /// Total cache operation time in nanoseconds
     pub total_duration_ns: u64,
@@ -332,7 +330,7 @@ pub struct CsvResultRow {
     pub get_max_ns: u64,
     pub get_p50_ns: u64,
     pub get_p99_ns: u64,
-    // Put operation stats
+    // Put operation stats (all put operations, with or without size)
     pub put_ops: u64,
     pub put_duration_ns: u64,
     pub put_ops_per_sec: f64,
@@ -341,13 +339,4 @@ pub struct CsvResultRow {
     pub put_max_ns: u64,
     pub put_p50_ns: u64,
     pub put_p99_ns: u64,
-    // Put with size operation stats
-    pub put_size_ops: u64,
-    pub put_size_duration_ns: u64,
-    pub put_size_ops_per_sec: f64,
-    pub put_size_avg_ns: f64,
-    pub put_size_min_ns: u64,
-    pub put_size_max_ns: u64,
-    pub put_size_p50_ns: u64,
-    pub put_size_p99_ns: u64,
 }

--- a/cache-simulator/src/runner.rs
+++ b/cache-simulator/src/runner.rs
@@ -55,7 +55,7 @@ const DEFAULT_SEGMENT_COUNT: usize = 16;
 /// Wrapper enum for all cache implementations
 /// This allows us to handle both sequential and concurrent caches uniformly
 ///
-/// Variants ending in `Size` use `put_with_size` for size-based eviction.
+/// Variants ending in `Size` use `put(key, value, Some(size))` for size-based eviction.
 /// This avoids per-request `if` checks by encoding the mode in the variant.
 #[allow(dead_code)]
 enum CacheWrapper {
@@ -183,10 +183,8 @@ impl OpLatencyTracker {
 struct LatencyTracker {
     /// Get operation latencies
     get_tracker: OpLatencyTracker,
-    /// Put operation latencies (regular put)
+    /// Put operation latencies (all put operations, with or without size)
     put_tracker: OpLatencyTracker,
-    /// Put with size operation latencies
-    put_with_size_tracker: OpLatencyTracker,
 }
 
 impl LatencyTracker {
@@ -194,7 +192,6 @@ impl LatencyTracker {
         Self {
             get_tracker: OpLatencyTracker::new(),
             put_tracker: OpLatencyTracker::new(),
-            put_with_size_tracker: OpLatencyTracker::new(),
         }
     }
 
@@ -210,29 +207,19 @@ impl LatencyTracker {
         self.put_tracker.record(latency_ns);
     }
 
-    /// Record a put_with_size operation latency
-    #[inline]
-    fn record_put_with_size(&mut self, latency_ns: u64) {
-        self.put_with_size_tracker.record(latency_ns);
-    }
-
     /// Convert to LatencyStats (consumes internal state)
     fn finalize_stats(&mut self) -> crate::models::LatencyStats {
         use crate::models::LatencyStats;
 
         // Calculate combined stats
-        let total_ns = self.get_tracker.total_ns
-            + self.put_tracker.total_ns
-            + self.put_with_size_tracker.total_ns;
-        let total_count =
-            self.get_tracker.count + self.put_tracker.count + self.put_with_size_tracker.count;
+        let total_ns = self.get_tracker.total_ns + self.put_tracker.total_ns;
+        let total_count = self.get_tracker.count + self.put_tracker.count;
 
         LatencyStats {
             total_ns,
             count: total_count,
             get_stats: self.get_tracker.finalize_op_stats(),
             put_stats: self.put_tracker.finalize_op_stats(),
-            put_with_size_stats: self.put_with_size_tracker.finalize_op_stats(),
         }
     }
 }
@@ -301,25 +288,8 @@ impl CacheWrapper {
         }
     }
 
-    /// Returns true if this cache uses put_with_size (size-based eviction)
-    fn uses_size_based_put(&self) -> bool {
-        matches!(
-            self,
-            CacheWrapper::LruSeqSize(_)
-                | CacheWrapper::LfuSeqSize(_)
-                | CacheWrapper::LfudaSeqSize(_)
-                | CacheWrapper::SlruSeqSize(_)
-                | CacheWrapper::LruConcSize(_)
-                | CacheWrapper::LfuConcSize(_)
-                | CacheWrapper::LfudaConcSize(_)
-                | CacheWrapper::SlruConcSize(_)
-                | CacheWrapper::GdsfSeq(_)
-                | CacheWrapper::GdsfConc(_)
-        )
-    }
-
     /// Insert a value into the cache
-    /// Size-based variants use put_with_size, entry-count variants use put
+    /// Size-based variants use put with Some(size), entry-count variants use put with None
     fn put(&mut self, key: String, size: usize) {
         let safe_size = size.max(1) as u64;
         let value = size as u32;
@@ -327,61 +297,61 @@ impl CacheWrapper {
         match self {
             // Sequential - entry count mode (no size tracking)
             CacheWrapper::LruSeq(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::LfuSeq(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::LfudaSeq(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::SlruSeq(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::GdsfSeq(c) => {
-                c.put(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             } // GDSF always uses size
             // Sequential - size-based mode
             CacheWrapper::LruSeqSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             CacheWrapper::LfuSeqSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             CacheWrapper::LfudaSeqSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             CacheWrapper::SlruSeqSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             // Concurrent - entry count mode
             CacheWrapper::LruConc(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::LfuConc(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::LfudaConc(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::SlruConc(c) => {
-                c.put(key, value);
+                c.put(key, value, None);
             }
             CacheWrapper::GdsfConc(c) => {
-                c.put(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             } // GDSF always uses size
             // Concurrent - size-based mode
             CacheWrapper::LruConcSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             CacheWrapper::LfuConcSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             CacheWrapper::LfudaConcSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             CacheWrapper::SlruConcSize(c) => {
-                c.put_with_size(key, value, safe_size);
+                c.put(key, value, Some(safe_size));
             }
             // External caches (Moka handles size via weigher at build time)
             CacheWrapper::Moka(c) => {
@@ -799,9 +769,6 @@ impl SimulationRunner {
                 // Track latency of cache operations (separate from I/O)
                 let mut latency_tracker = LatencyTracker::new();
 
-                // Check if this cache uses put_with_size
-                let uses_size_put = cache.uses_size_based_put();
-
                 // Stream through all requests
                 let mut request_iter = match log_reader.stream_requests() {
                     Ok(iter) => iter,
@@ -829,12 +796,8 @@ impl SimulationRunner {
                         cache.put(request.key.clone(), request.size);
                         let put_duration = put_start.elapsed().as_nanos() as u64;
 
-                        // Record to appropriate tracker based on put type
-                        if uses_size_put {
-                            latency_tracker.record_put_with_size(put_duration);
-                        } else {
-                            latency_tracker.record_put(put_duration);
-                        }
+                        // Record put latency (unified API)
+                        latency_tracker.record_put(put_duration);
 
                         stats.record_miss(key, request.size);
                         storage_tracker.add(request.size);
@@ -913,9 +876,8 @@ impl SimulationRunner {
                     get_pct.map(|p| p.p99_ns).unwrap_or(0)
                 );
 
-                // Print PUT stats (either put or put_with_size, whichever was used)
+                // Print PUT stats (unified API)
                 let put = &latency_stats.put_stats;
-                let put_size = &latency_stats.put_with_size_stats;
 
                 if put.count > 0 {
                     let put_pct = put.percentiles.as_ref();
@@ -929,21 +891,6 @@ impl SimulationRunner {
                         put.max_ns,
                         put_pct.map(|p| p.p50_ns).unwrap_or(0),
                         put_pct.map(|p| p.p99_ns).unwrap_or(0)
-                    );
-                }
-
-                if put_size.count > 0 {
-                    let put_size_pct = put_size.percentiles.as_ref();
-                    println!(
-                        "    PUT+SIZE: {} ops in {:.3}s = {:.0} ops/s | avg={:.0}ns min={} max={} p50={} p99={}",
-                        put_size.count,
-                        put_size.duration_secs(),
-                        put_size.ops_per_sec(),
-                        put_size.avg_ns(),
-                        put_size.min_ns,
-                        put_size.max_ns,
-                        put_size_pct.map(|p| p.p50_ns).unwrap_or(0),
-                        put_size_pct.map(|p| p.p99_ns).unwrap_or(0)
                     );
                 }
 

--- a/cache-simulator/src/runner.rs
+++ b/cache-simulator/src/runner.rs
@@ -55,7 +55,7 @@ const DEFAULT_SEGMENT_COUNT: usize = 16;
 /// Wrapper enum for all cache implementations
 /// This allows us to handle both sequential and concurrent caches uniformly
 ///
-/// Variants ending in `Size` use `put(key, value, Some(size))` for size-based eviction.
+/// Variants ending in `Size` use `put(key, value, size)` for size-based eviction.
 /// This avoids per-request `if` checks by encoding the mode in the variant.
 #[allow(dead_code)]
 enum CacheWrapper {
@@ -297,61 +297,61 @@ impl CacheWrapper {
         match self {
             // Sequential - entry count mode (no size tracking)
             CacheWrapper::LruSeq(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::LfuSeq(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::LfudaSeq(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::SlruSeq(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::GdsfSeq(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             } // GDSF always uses size
             // Sequential - size-based mode
             CacheWrapper::LruSeqSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             CacheWrapper::LfuSeqSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             CacheWrapper::LfudaSeqSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             CacheWrapper::SlruSeqSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             // Concurrent - entry count mode
             CacheWrapper::LruConc(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::LfuConc(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::LfudaConc(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::SlruConc(c) => {
-                c.put(key, value, None);
+                c.put(key, value, 1);
             }
             CacheWrapper::GdsfConc(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             } // GDSF always uses size
             // Concurrent - size-based mode
             CacheWrapper::LruConcSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             CacheWrapper::LfuConcSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             CacheWrapper::LfudaConcSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             CacheWrapper::SlruConcSize(c) => {
-                c.put(key, value, Some(safe_size));
+                c.put(key, value, safe_size);
             }
             // External caches (Moka handles size via weigher at build time)
             CacheWrapper::Moka(c) => {

--- a/cache-simulator/src/stats.rs
+++ b/cache-simulator/src/stats.rs
@@ -186,18 +186,8 @@ impl SimulationStats {
                     .map(|p| p.p99_ns)
                     .unwrap_or(0);
 
-                // Determine which put type was used
-                let (put_avg, _put_count) = if stats.latency.put_stats.count > 0 {
-                    (
-                        stats.latency.put_stats.avg_ns(),
-                        stats.latency.put_stats.count,
-                    )
-                } else {
-                    (
-                        stats.latency.put_with_size_stats.avg_ns(),
-                        stats.latency.put_with_size_stats.count,
-                    )
-                };
+                // Get put stats (unified API)
+                let put_avg = stats.latency.put_stats.avg_ns();
 
                 println!(
                     "{:<6} {:<10} {:>7.2}% {:>9.2}% {:>12} {:>9.3}s {:>10.0} {:>9.0}ns {:>9.0}ns {:>9}ns",
@@ -366,27 +356,6 @@ impl SimulationStats {
                     put_p99_ns: stats
                         .latency
                         .put_stats
-                        .percentiles
-                        .as_ref()
-                        .map(|p| p.p99_ns)
-                        .unwrap_or(0),
-                    // Put with size stats
-                    put_size_ops: stats.latency.put_with_size_stats.count,
-                    put_size_duration_ns: stats.latency.put_with_size_stats.total_ns,
-                    put_size_ops_per_sec: stats.latency.put_with_size_stats.ops_per_sec(),
-                    put_size_avg_ns: stats.latency.put_with_size_stats.avg_ns(),
-                    put_size_min_ns: stats.latency.put_with_size_stats.min_ns,
-                    put_size_max_ns: stats.latency.put_with_size_stats.max_ns,
-                    put_size_p50_ns: stats
-                        .latency
-                        .put_with_size_stats
-                        .percentiles
-                        .as_ref()
-                        .map(|p| p.p50_ns)
-                        .unwrap_or(0),
-                    put_size_p99_ns: stats
-                        .latency
-                        .put_with_size_stats
                         .percentiles
                         .as_ref()
                         .map(|p| p.p99_ns)

--- a/docs/design-spec/unified-put-api-spec.md
+++ b/docs/design-spec/unified-put-api-spec.md
@@ -1,0 +1,278 @@
+# Unified `put` API Specification
+
+## Overview
+
+**Work Type**: ALGORITHM ENHANCEMENT  
+**Algorithms Affected**: All 5 (LRU, LFU, LFUDA, SLRU, GDSF) + all concurrent variants  
+**Breaking Change**: Yes - removes `put_with_size()` method
+
+### Problem Statement
+
+The current API has inconsistent signatures:
+- LRU, LFU, LFUDA, SLRU: `put(key, value)` + `put_with_size(key, value, size)`
+- GDSF: `put(key, value, size)` only (size required)
+
+This creates API inconsistency and forces users to remember different signatures per algorithm.
+
+### Solution
+
+Unify all algorithms to use a single signature:
+```rust
+pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+```
+
+When `size` is `None`, default to `1` (count-based caching).
+
+---
+
+## API Design
+
+### New Unified Signature
+
+**Single-threaded caches:**
+```rust
+impl<K, V, S> [Algorithm]Cache<K, V, S> {
+    /// Inserts a key-value pair into the cache.
+    ///
+    /// # Arguments
+    /// * `key` - The key to insert
+    /// * `value` - The value to cache  
+    /// * `size` - Size of this entry for capacity tracking. `None` defaults to `1`.
+    ///
+    /// # Returns
+    /// Returns `Some((evicted_key, evicted_value))` if an entry was evicted or replaced,
+    /// `None` if inserted without eviction.
+    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+}
+```
+
+**Concurrent caches:**
+```rust
+impl<K, V, S> Concurrent[Algorithm]<K, V, S> {
+    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+}
+```
+
+### Return Type Consideration
+
+**Current inconsistency:**
+- Most algorithms return `Option<(K, V)>` from `put()`
+- GDSF returns `Option<V>` from `put()` (no key returned)
+
+**Decision**: Keep GDSF's return type as `Option<V>` for backward compatibility within this change. A separate enhancement could unify return types later if desired.
+
+### Migration Path
+
+```rust
+// Before (LRU, LFU, LFUDA, SLRU)
+cache.put("key", value);                    // count-based
+cache.put_with_size("key", value, 1000);    // size-based
+
+// After (all algorithms)
+cache.put("key", value, None);              // count-based (size=1)
+cache.put("key", value, Some(1000));        // size-based
+
+// Before (GDSF only)
+cache.put("key", value, 1000);              // size required
+
+// After (GDSF)
+cache.put("key", value, None);              // size defaults to 1
+cache.put("key", value, Some(1000));        // explicit size
+```
+
+---
+
+## Implementation Strategy
+
+### Phase 1: Single-Threaded Caches
+
+Modify these files:
+
+| File | Current Methods | New Signature |
+|------|-----------------|---------------|
+| `src/lru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/lfu.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/lfuda.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/slru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/gdsf.rs` | `put(k, v, size)` | `put(k, v, size: Option<u64>)` |
+
+**Implementation pattern for LRU/LFU/LFUDA/SLRU:**
+```rust
+// Segment level
+pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+where
+    K: Clone + Hash + Eq,
+{
+    let object_size = size.unwrap_or(1);
+    // ... existing put_with_size logic with object_size ...
+}
+
+// Cache wrapper level
+pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+    self.segment.put(key, value, size)
+}
+```
+
+**Implementation pattern for GDSF:**
+```rust
+// Segment level
+pub(crate) fn put(&mut self, key: K, val: V, size: Option<u64>) -> Option<V>
+where
+    K: Clone,
+{
+    let object_size = size.unwrap_or(1);
+    // ... existing put logic with object_size ...
+}
+```
+
+### Phase 2: Concurrent Caches
+
+Modify these files:
+
+| File | Current Methods | New Signature |
+|------|-----------------|---------------|
+| `src/concurrent/lru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/concurrent/lfu.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/concurrent/lfuda.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/concurrent/slru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
+| `src/concurrent/gdsf.rs` | `put(k, v, size)` | `put(k, v, size: Option<u64>)` |
+
+### Phase 3: Update Tests
+
+Files requiring updates:
+
+- `tests/correctness_tests.rs` - Update all `put()` and `put_with_size()` calls
+- `tests/concurrent_correctness_tests.rs` - Update concurrent cache tests
+- `tests/concurrent_stress_tests.rs` - Update stress tests
+- `tests/no_std_tests.rs` - Update no_std compatibility tests
+
+**Migration pattern:**
+```rust
+// Before
+cache.put("key", value);
+cache.put_with_size("key", value, 100);
+
+// After
+cache.put("key", value, None);
+cache.put("key", value, Some(100));
+```
+
+### Phase 4: Update Examples
+
+Files requiring updates:
+
+- `examples/cache_comparison.rs`
+- `examples/concurrent_usage.rs`
+- `examples/metrics_demo.rs`
+
+### Phase 5: Update Documentation
+
+Files requiring updates:
+
+- `README.md` - Update API table and usage examples
+- Doc comments in all modified source files
+
+### Phase 6: Update Cache Simulator
+
+The `cache-simulator/` tracks `put_with_size` operations separately in latency stats. This needs updating:
+
+- `cache-simulator/src/stats.rs` - Remove separate `put_with_size_stats` tracking (merge into `put_stats`)
+- `cache-simulator/src/runner.rs` - Update cache operation calls
+
+---
+
+## Removed Methods
+
+The following methods will be DELETED:
+
+```rust
+// Single-threaded (public API)
+LruCache::put_with_size()
+LfuCache::put_with_size()
+LfudaCache::put_with_size()
+SlruCache::put_with_size()
+
+// Concurrent (public API)
+ConcurrentLru::put_with_size()
+ConcurrentLfu::put_with_size()
+ConcurrentLfuda::put_with_size()
+ConcurrentSlru::put_with_size()
+
+// Segment level (internal)
+LruSegment::put_with_size()
+LfuSegment::put_with_size()
+LfudaSegment::put_with_size()
+SlruSegment::put_with_size()
+```
+
+Also remove: `estimate_object_size()` methods become unnecessary (can be deleted or kept internal).
+
+---
+
+## Performance Impact
+
+**No performance impact expected:**
+- The unified `put()` simply uses `unwrap_or(1)` which is a trivial operation
+- Existing `put()` already called `put_with_size()` internally
+- No additional allocations or computations
+
+**Complexity remains O(1)** for all operations.
+
+---
+
+## Breaking Change Documentation
+
+Add to CHANGELOG.md:
+
+```markdown
+## [Unreleased] - Breaking Changes
+
+### Changed
+- **BREAKING**: Unified `put()` API across all cache algorithms
+  - Signature changed from `put(key, value)` to `put(key, value, size: Option<u64>)`
+  - `put_with_size(key, value, size)` method removed - use `put(key, value, Some(size))` instead
+  - GDSF now accepts `None` for size (defaults to 1) instead of requiring size parameter
+
+### Migration Guide
+```rust
+// Count-based caching (before)
+cache.put("key", value);
+// Count-based caching (after)  
+cache.put("key", value, None);
+
+// Size-based caching (before)
+cache.put_with_size("key", value, 1000);
+// Size-based caching (after)
+cache.put("key", value, Some(1000));
+```
+```
+
+---
+
+## Validation Checklist
+
+After implementation, verify:
+
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo clippy --all-targets --features concurrent -- -D warnings` passes
+- [ ] `cargo clippy --all-targets --features std,concurrent -- -D warnings` passes
+- [ ] `cargo test --features "std,concurrent"` passes
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --features concurrent` passes
+- [ ] All examples compile and run correctly
+- [ ] Cache simulator compiles and runs correctly
+
+---
+
+## Files to Modify Summary
+
+| Category | Files |
+|----------|-------|
+| **Single-threaded caches** | `src/lru.rs`, `src/lfu.rs`, `src/lfuda.rs`, `src/slru.rs`, `src/gdsf.rs` |
+| **Concurrent caches** | `src/concurrent/lru.rs`, `src/concurrent/lfu.rs`, `src/concurrent/lfuda.rs`, `src/concurrent/slru.rs`, `src/concurrent/gdsf.rs` |
+| **Tests** | `tests/correctness_tests.rs`, `tests/concurrent_correctness_tests.rs`, `tests/concurrent_stress_tests.rs`, `tests/no_std_tests.rs` |
+| **Examples** | `examples/cache_comparison.rs`, `examples/concurrent_usage.rs`, `examples/metrics_demo.rs` |
+| **Documentation** | `README.md`, `CHANGELOG.md` |
+| **Simulator** | `cache-simulator/src/stats.rs`, `cache-simulator/src/runner.rs` |
+
+**Estimated scope**: ~15 files, primarily mechanical search-and-replace with signature changes.

--- a/docs/design-spec/unified-put-api-spec.md
+++ b/docs/design-spec/unified-put-api-spec.md
@@ -16,18 +16,22 @@ This creates API inconsistency and forces users to remember different signatures
 
 ### Solution
 
-Unify all algorithms to use a single signature:
+Unify all algorithms to use a single signature with **required** size parameter:
 ```rust
-pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
 ```
 
-When `size` is `None`, default to `1` (count-based caching).
+Provide `SIZE_UNIT` constant for entry-count mode (where size tracking doesn't matter).
+
+> **Note**: The initial implementation used `Option<u64>` with `None` defaulting to `1`.
+> After analysis (see "Size Parameter Analysis" section below), this was found to be 
+> problematic. The recommended approach is to make `size` required.
 
 ---
 
 ## API Design
 
-### New Unified Signature
+### Final Unified Signature
 
 **Single-threaded caches:**
 ```rust
@@ -37,20 +41,27 @@ impl<K, V, S> [Algorithm]Cache<K, V, S> {
     /// # Arguments
     /// * `key` - The key to insert
     /// * `value` - The value to cache  
-    /// * `size` - Size of this entry for capacity tracking. `None` defaults to `1`.
+    /// * `size` - Size of this entry for capacity tracking. Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Returns
     /// Returns `Some((evicted_key, evicted_value))` if an entry was evicted or replaced,
     /// `None` if inserted without eviction.
-    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
 }
 ```
 
 **Concurrent caches:**
 ```rust
 impl<K, V, S> Concurrent[Algorithm]<K, V, S> {
-    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    pub fn put(&self, key: K, value: V, size: u64) -> Option<(K, V)>
 }
+```
+
+**SIZE_UNIT Constant:**
+```rust
+/// Size value for entry-count mode where actual size doesn't matter.
+/// Use this when you only want to limit the number of entries, not total size.
+pub const SIZE_UNIT: u64 = 1;
 ```
 
 ### Return Type Consideration
@@ -69,15 +80,15 @@ cache.put("key", value);                    // count-based
 cache.put_with_size("key", value, 1000);    // size-based
 
 // After (all algorithms)
-cache.put("key", value, None);              // count-based (size=1)
-cache.put("key", value, Some(1000));        // size-based
+cache.put("key", value, SIZE_UNIT);         // count-based (explicit)
+cache.put("key", value, 1000);              // size-based (no wrapping)
 
 // Before (GDSF only)
 cache.put("key", value, 1000);              // size required
 
-// After (GDSF)
-cache.put("key", value, None);              // size defaults to 1
-cache.put("key", value, Some(1000));        // explicit size
+// After (GDSF) - no change needed for size-based calls
+cache.put("key", value, SIZE_UNIT);         // count-based (new capability)
+cache.put("key", value, 1000);              // size-based (unchanged)
 ```
 
 ---
@@ -90,25 +101,25 @@ Modify these files:
 
 | File | Current Methods | New Signature |
 |------|-----------------|---------------|
-| `src/lru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/lfu.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/lfuda.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/slru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/gdsf.rs` | `put(k, v, size)` | `put(k, v, size: Option<u64>)` |
+| `src/lru.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/lfu.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/lfuda.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/slru.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/gdsf.rs` | `put(k, v, size)` | `put(k, v, size: u64)` |
 
 **Implementation pattern for LRU/LFU/LFUDA/SLRU:**
 ```rust
 // Segment level
-pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+pub(crate) fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
 where
     K: Clone + Hash + Eq,
 {
-    let object_size = size.unwrap_or(1);
-    // ... existing put_with_size logic with object_size ...
+    // Size is now required - use directly
+    // ... existing put logic with size ...
 }
 
 // Cache wrapper level
-pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)> {
     self.segment.put(key, value, size)
 }
 ```
@@ -116,12 +127,12 @@ pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
 **Implementation pattern for GDSF:**
 ```rust
 // Segment level
-pub(crate) fn put(&mut self, key: K, val: V, size: Option<u64>) -> Option<V>
+pub(crate) fn put(&mut self, key: K, val: V, size: u64) -> Option<V>
 where
     K: Clone,
 {
-    let object_size = size.unwrap_or(1);
-    // ... existing put logic with object_size ...
+    // Size is now required - use directly
+    // ... existing put logic with size ...
 }
 ```
 
@@ -131,17 +142,17 @@ Modify these files:
 
 | File | Current Methods | New Signature |
 |------|-----------------|---------------|
-| `src/concurrent/lru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/concurrent/lfu.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/concurrent/lfuda.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/concurrent/slru.rs` | `put()`, `put_with_size()` | `put(k, v, size: Option<u64>)` |
-| `src/concurrent/gdsf.rs` | `put(k, v, size)` | `put(k, v, size: Option<u64>)` |
+| `src/concurrent/lru.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/concurrent/lfu.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/concurrent/lfuda.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/concurrent/slru.rs` | `put()`, `put_with_size()` | `put(k, v, size: u64)` |
+| `src/concurrent/gdsf.rs` | `put(k, v, size)` | `put(k, v, size: u64)` |
 
 ### Phase 3: Update Tests
 
 Files requiring updates:
 
-- `tests/correctness_tests.rs` - Update all `put()` and `put_with_size()` calls
+- `tests/correctness_tests.rs` - Update all `put()` calls
 - `tests/concurrent_correctness_tests.rs` - Update concurrent cache tests
 - `tests/concurrent_stress_tests.rs` - Update stress tests
 - `tests/no_std_tests.rs` - Update no_std compatibility tests
@@ -206,6 +217,114 @@ SlruSegment::put_with_size()
 ```
 
 Also remove: `estimate_object_size()` methods become unnecessary (can be deleted or kept internal).
+
+---
+
+## Size Parameter Analysis: Why Not Default to Value Size?
+
+### The Problem with `None → 1`
+
+The current implementation defaults `size` to `1` when `None` is passed. This is **problematic** for several reasons:
+
+1. **Memory Budget Violation**: If `max_size = 10MB` and entries are actually 1MB each:
+   - Cache thinks each entry is 1 byte
+   - Allows 10 million entries before hitting `max_size`
+   - Actual memory: 10TB → OOM
+
+2. **Size-Aware Algorithm Defeat**: GDSF and LFUDA use size for eviction priority:
+   ```
+   GDSF priority = frequency / size
+   ```
+   With `size=1`, all entries have equal size weight, defeating the algorithm's purpose.
+
+3. **Silent Failure Mode**: No warning when using `None` with size-constrained caches.
+
+### Why Can't We Use `size_of::<V>()` as Default?
+
+Rust's type system cannot determine the "true" memory footprint of heap-allocated types:
+
+```rust
+// std::mem::size_of::<V>() only measures STACK size, not heap
+size_of::<String>()     // → 24 bytes (3 pointers), regardless of string length
+size_of::<Vec<u8>>()    // → 24 bytes, regardless of capacity
+size_of::<Box<[u8]>>()  // → 16 bytes, regardless of slice length
+
+// A 1MB String still reports 24 bytes
+let s = "x".repeat(1_000_000);
+size_of_val(&s)  // → 24 bytes (WRONG for cache sizing!)
+```
+
+### Alternative Approaches Considered
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A. Make size required** | Forces explicit decision; no silent failures | More verbose for count-based use |
+| **B. `Sizable` trait** | Auto-compute for implementing types | Adds trait bound; breaks generic V; no_std complexity |
+| **C. `size_of::<V>()` default** | Automatic, no trait needed | Wrong for heap types; misleading |
+| **D. Weigher function** (like Moka) | Consistent per-cache sizing | Major API redesign; closure complexity |
+| **E. Keep `None → 1`** | Simple; backward compatible | Silent failures; misleading semantics |
+
+### Recommended Solution: Make Size Required
+
+**Change the API to require size explicitly:**
+
+```rust
+// NEW: Size is required (u64, not Option<u64>)
+pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
+
+// Provide a convenience constant for entry-count mode
+pub const SIZE_UNIT: u64 = 1;
+```
+
+**Usage patterns:**
+
+```rust
+// Entry-count mode (just limit number of entries)
+cache.put("key", value, SIZE_UNIT);
+
+// Size-aware mode (track actual memory/disk usage)
+cache.put("key", data, data.len() as u64);
+cache.put("key", response, response.body.len() as u64);
+
+// For structs, user computes size
+cache.put("key", user, size_of::<User>() as u64 + user.name.len() as u64);
+```
+
+### Rationale
+
+1. **Explicit is better than implicit**: Users MUST think about what size means for their workload.
+
+2. **No silent failures**: Can't accidentally use wrong size with `None`.
+
+3. **Cache semantics documented**: Using `SIZE_UNIT` explicitly signals "I want count-based caching."
+
+4. **Real-world alignment**: 
+   - In-memory caches: User knows actual heap allocation
+   - Disk/external caches: User knows external resource size
+   - Neither case can be inferred from `V`'s type
+
+5. **No_std compatible**: No traits or closures required.
+
+### Migration from `Option<u64>` to `u64`
+
+```rust
+// Before (problematic)
+cache.put("key", value, None);           // Silent size=1, may cause OOM
+cache.put("key", value, Some(1000));     // Explicit size
+
+// After (explicit)
+cache.put("key", value, SIZE_UNIT);      // Clearly indicates count-based
+cache.put("key", value, 1000);           // Size-based, no wrapping needed
+```
+
+### Implementation Impact
+
+If we proceed with required size:
+
+1. **API Signature**: `put(key, value, size: u64)` instead of `put(key, value, size: Option<u64>)`
+2. **Add constant**: `pub const SIZE_UNIT: u64 = 1;` in lib.rs or dedicated module
+3. **Update all call sites**: Replace `None` with `SIZE_UNIT`, unwrap `Some(x)` to `x`
+4. **Documentation**: Clearly explain when to use `SIZE_UNIT` vs actual size
 
 ---
 

--- a/examples/cache_comparison.rs
+++ b/examples/cache_comparison.rs
@@ -66,7 +66,7 @@ fn main() {
 
     println!("\n1. LRU Cache (Least Recently Used):");
     for (key, value) in &data {
-        if let Some(evicted) = lru_cache.put(*key, *value, None) {
+        if let Some(evicted) = lru_cache.put(*key, *value, 1) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -74,7 +74,7 @@ fn main() {
 
     println!("\n2. SLRU Cache (Segmented LRU):");
     for (key, value) in &data {
-        if let Some(evicted) = slru_cache.put(*key, *value, None) {
+        if let Some(evicted) = slru_cache.put(*key, *value, 1) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -82,7 +82,7 @@ fn main() {
 
     println!("\n3. LFU Cache (Least Frequently Used):");
     for (key, value) in &data {
-        if let Some(evicted) = lfu_cache.put(*key, *value, None) {
+        if let Some(evicted) = lfu_cache.put(*key, *value, 1) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -90,7 +90,7 @@ fn main() {
 
     println!("\n4. LFUDA Cache (LFU with Dynamic Aging):");
     for (key, value) in &data {
-        if let Some(evicted) = lfuda_cache.put(*key, *value, None) {
+        if let Some(evicted) = lfuda_cache.put(*key, *value, 1) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -101,7 +101,7 @@ fn main() {
         "   GDSF considers both frequency and size. Priority = (Frequency / Size) + Global_Age"
     );
     for (key, value, size) in &gdsf_data {
-        if let Some(evicted) = gdsf_cache.put(*key, *value, Some(*size)) {
+        if let Some(evicted) = gdsf_cache.put(*key, *value, *size) {
             println!("   Evicted: {evicted:?}");
         }
         println!(
@@ -130,23 +130,23 @@ fn main() {
 
     println!("\nAdding 'elderberry' to see different eviction behaviors...");
 
-    if let Some(evicted) = lru_cache.put("elderberry", 5, None) {
+    if let Some(evicted) = lru_cache.put("elderberry", 5, 1) {
         println!("LRU evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = slru_cache.put("elderberry", 5, None) {
+    if let Some(evicted) = slru_cache.put("elderberry", 5, 1) {
         println!("SLRU evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = lfu_cache.put("elderberry", 5, None) {
+    if let Some(evicted) = lfu_cache.put("elderberry", 5, 1) {
         println!("LFU evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = lfuda_cache.put("elderberry", 5, None) {
+    if let Some(evicted) = lfuda_cache.put("elderberry", 5, 1) {
         println!("LFUDA evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = gdsf_cache.put("elderberry", 5, Some(8)) {
+    if let Some(evicted) = gdsf_cache.put("elderberry", 5, 8) {
         println!(
             "GDSF evicted: {evicted:?} (algorithm chose based on lowest (frequency/size) + global_age)"
         );

--- a/examples/cache_comparison.rs
+++ b/examples/cache_comparison.rs
@@ -66,7 +66,7 @@ fn main() {
 
     println!("\n1. LRU Cache (Least Recently Used):");
     for (key, value) in &data {
-        if let Some(evicted) = lru_cache.put(*key, *value) {
+        if let Some(evicted) = lru_cache.put(*key, *value, None) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -74,7 +74,7 @@ fn main() {
 
     println!("\n2. SLRU Cache (Segmented LRU):");
     for (key, value) in &data {
-        if let Some(evicted) = slru_cache.put(*key, *value) {
+        if let Some(evicted) = slru_cache.put(*key, *value, None) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -82,7 +82,7 @@ fn main() {
 
     println!("\n3. LFU Cache (Least Frequently Used):");
     for (key, value) in &data {
-        if let Some(evicted) = lfu_cache.put(*key, *value) {
+        if let Some(evicted) = lfu_cache.put(*key, *value, None) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -90,7 +90,7 @@ fn main() {
 
     println!("\n4. LFUDA Cache (LFU with Dynamic Aging):");
     for (key, value) in &data {
-        if let Some(evicted) = lfuda_cache.put(*key, *value) {
+        if let Some(evicted) = lfuda_cache.put(*key, *value, None) {
             println!("   Evicted: {evicted:?}");
         }
         println!("   Added: {key} -> {value}");
@@ -101,7 +101,7 @@ fn main() {
         "   GDSF considers both frequency and size. Priority = (Frequency / Size) + Global_Age"
     );
     for (key, value, size) in &gdsf_data {
-        if let Some(evicted) = gdsf_cache.put(*key, *value, *size) {
+        if let Some(evicted) = gdsf_cache.put(*key, *value, Some(*size)) {
             println!("   Evicted: {evicted:?}");
         }
         println!(
@@ -130,23 +130,23 @@ fn main() {
 
     println!("\nAdding 'elderberry' to see different eviction behaviors...");
 
-    if let Some(evicted) = lru_cache.put("elderberry", 5) {
+    if let Some(evicted) = lru_cache.put("elderberry", 5, None) {
         println!("LRU evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = slru_cache.put("elderberry", 5) {
+    if let Some(evicted) = slru_cache.put("elderberry", 5, None) {
         println!("SLRU evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = lfu_cache.put("elderberry", 5) {
+    if let Some(evicted) = lfu_cache.put("elderberry", 5, None) {
         println!("LFU evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = lfuda_cache.put("elderberry", 5) {
+    if let Some(evicted) = lfuda_cache.put("elderberry", 5, None) {
         println!("LFUDA evicted: {evicted:?}");
     }
 
-    if let Some(evicted) = gdsf_cache.put("elderberry", 5, 8) {
+    if let Some(evicted) = gdsf_cache.put("elderberry", 5, Some(8)) {
         println!(
             "GDSF evicted: {evicted:?} (algorithm chose based on lowest (frequency/size) + global_age)"
         );

--- a/examples/concurrent_usage.rs
+++ b/examples/concurrent_usage.rs
@@ -113,7 +113,7 @@ fn basic_concurrent_usage() {
                     let value = thread_id * 10000 + i;
 
                     // Write
-                    cache.put(key.clone(), value, None);
+                    cache.put(key.clone(), value, 1);
 
                     // Read
                     if let Some(v) = cache.get(&key) {
@@ -147,7 +147,7 @@ fn zero_copy_get_with() {
 
     // Store a large value
     let large_data = vec![1u8; 1024]; // 1KB of data
-    cache.put("large_key".to_string(), large_data, None);
+    cache.put("large_key".to_string(), large_data, 1);
 
     // Process the value without cloning using get_with()
     let sum: Option<u64> = cache.get_with(&"large_key".to_string(), |data| {
@@ -213,31 +213,31 @@ fn all_concurrent_cache_types() {
 
     // ConcurrentLruCache - General purpose
     let lru: ConcurrentLruCache<String, i32> = ConcurrentLruCache::init(lru_config(100, 16), None);
-    lru.put("key".to_string(), 1, None);
+    lru.put("key".to_string(), 1, 1);
     println!("   ConcurrentLruCache: General purpose, recency-based");
 
     // ConcurrentSlruCache - Scan resistant
     let slru: ConcurrentSlruCache<String, i32> =
         ConcurrentSlruCache::init(slru_config(100, 20, 16), None);
-    slru.put("key".to_string(), 1, None);
+    slru.put("key".to_string(), 1, 1);
     println!("   ConcurrentSlruCache: Scan resistant, two-segment design");
 
     // ConcurrentLfuCache - Frequency based
     let lfu: ConcurrentLfuCache<String, i32> = ConcurrentLfuCache::init(lfu_config(100, 16), None);
-    lfu.put("key".to_string(), 1, None);
+    lfu.put("key".to_string(), 1, 1);
     println!("   ConcurrentLfuCache: Frequency-based eviction");
 
     // ConcurrentLfudaCache - Adaptive frequency
     let lfuda: ConcurrentLfudaCache<String, i32> =
         ConcurrentLfudaCache::init(lfuda_config(100, 16), None);
-    lfuda.put("key".to_string(), 1, None);
+    lfuda.put("key".to_string(), 1, 1);
     println!("   ConcurrentLfudaCache: Frequency + aging for changing patterns");
 
     // ConcurrentGdsfCache - Size-aware (note: put takes size parameter)
     let gdsf: ConcurrentGdsfCache<String, Vec<u8>> =
         ConcurrentGdsfCache::init(gdsf_config(10000, 16), None);
-    gdsf.put("small.txt".to_string(), vec![0u8; 100], Some(100));
-    gdsf.put("large.jpg".to_string(), vec![0u8; 5000], Some(5000));
+    gdsf.put("small.txt".to_string(), vec![0u8; 100], 100);
+    gdsf.put("large.jpg".to_string(), vec![0u8; 5000], 5000);
     println!("   ConcurrentGdsfCache: Size-aware, for variable-size objects");
 }
 
@@ -262,7 +262,7 @@ fn throughput_comparison() {
                     let offset = t * ops_per_thread;
                     for i in 0..ops_per_thread {
                         let key = offset + i;
-                        cache.put(key, key, None);
+                        cache.put(key, key, 1);
                         cache.get(&key);
                     }
                 })

--- a/examples/concurrent_usage.rs
+++ b/examples/concurrent_usage.rs
@@ -113,7 +113,7 @@ fn basic_concurrent_usage() {
                     let value = thread_id * 10000 + i;
 
                     // Write
-                    cache.put(key.clone(), value);
+                    cache.put(key.clone(), value, None);
 
                     // Read
                     if let Some(v) = cache.get(&key) {
@@ -147,7 +147,7 @@ fn zero_copy_get_with() {
 
     // Store a large value
     let large_data = vec![1u8; 1024]; // 1KB of data
-    cache.put("large_key".to_string(), large_data);
+    cache.put("large_key".to_string(), large_data, None);
 
     // Process the value without cloning using get_with()
     let sum: Option<u64> = cache.get_with(&"large_key".to_string(), |data| {
@@ -213,31 +213,31 @@ fn all_concurrent_cache_types() {
 
     // ConcurrentLruCache - General purpose
     let lru: ConcurrentLruCache<String, i32> = ConcurrentLruCache::init(lru_config(100, 16), None);
-    lru.put("key".to_string(), 1);
+    lru.put("key".to_string(), 1, None);
     println!("   ConcurrentLruCache: General purpose, recency-based");
 
     // ConcurrentSlruCache - Scan resistant
     let slru: ConcurrentSlruCache<String, i32> =
         ConcurrentSlruCache::init(slru_config(100, 20, 16), None);
-    slru.put("key".to_string(), 1);
+    slru.put("key".to_string(), 1, None);
     println!("   ConcurrentSlruCache: Scan resistant, two-segment design");
 
     // ConcurrentLfuCache - Frequency based
     let lfu: ConcurrentLfuCache<String, i32> = ConcurrentLfuCache::init(lfu_config(100, 16), None);
-    lfu.put("key".to_string(), 1);
+    lfu.put("key".to_string(), 1, None);
     println!("   ConcurrentLfuCache: Frequency-based eviction");
 
     // ConcurrentLfudaCache - Adaptive frequency
     let lfuda: ConcurrentLfudaCache<String, i32> =
         ConcurrentLfudaCache::init(lfuda_config(100, 16), None);
-    lfuda.put("key".to_string(), 1);
+    lfuda.put("key".to_string(), 1, None);
     println!("   ConcurrentLfudaCache: Frequency + aging for changing patterns");
 
     // ConcurrentGdsfCache - Size-aware (note: put takes size parameter)
     let gdsf: ConcurrentGdsfCache<String, Vec<u8>> =
         ConcurrentGdsfCache::init(gdsf_config(10000, 16), None);
-    gdsf.put("small.txt".to_string(), vec![0u8; 100], 100);
-    gdsf.put("large.jpg".to_string(), vec![0u8; 5000], 5000);
+    gdsf.put("small.txt".to_string(), vec![0u8; 100], Some(100));
+    gdsf.put("large.jpg".to_string(), vec![0u8; 5000], Some(5000));
     println!("   ConcurrentGdsfCache: Size-aware, for variable-size objects");
 }
 
@@ -262,7 +262,7 @@ fn throughput_comparison() {
                     let offset = t * ops_per_thread;
                     for i in 0..ops_per_thread {
                         let key = offset + i;
-                        cache.put(key, key);
+                        cache.put(key, key, None);
                         cache.get(&key);
                     }
                 })

--- a/examples/metrics_demo.rs
+++ b/examples/metrics_demo.rs
@@ -59,9 +59,9 @@ fn test_lru_cache(capacity: NonZeroUsize) -> LruCache<&'static str, i32> {
     let mut cache = LruCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1, None);
-    cache.put("banana", 2, None);
-    cache.put("cherry", 3, None);
+    cache.put("apple", 1, 1);
+    cache.put("banana", 2, 1);
+    cache.put("cherry", 3, 1);
 
     // Access patterns (apple becomes most recently used)
     cache.get(&"apple");
@@ -73,8 +73,8 @@ fn test_lru_cache(capacity: NonZeroUsize) -> LruCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions (will trigger evictions)
-    cache.put("date", 4, None);
-    cache.put("elderberry", 5, None);
+    cache.put("date", 4, 1);
+    cache.put("elderberry", 5, 1);
 
     println!("   ✅ LRU test completed");
     cache
@@ -91,9 +91,9 @@ fn test_lfu_cache(capacity: NonZeroUsize) -> LfuCache<&'static str, i32> {
     let mut cache = LfuCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1, None);
-    cache.put("banana", 2, None);
-    cache.put("cherry", 3, None);
+    cache.put("apple", 1, 1);
+    cache.put("banana", 2, 1);
+    cache.put("cherry", 3, 1);
 
     // Access patterns (apple becomes most frequently used)
     cache.get(&"apple");
@@ -105,8 +105,8 @@ fn test_lfu_cache(capacity: NonZeroUsize) -> LfuCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions
-    cache.put("date", 4, None);
-    cache.put("elderberry", 5, None);
+    cache.put("date", 4, 1);
+    cache.put("elderberry", 5, 1);
 
     println!("   ✅ LFU test completed");
     cache
@@ -124,9 +124,9 @@ fn test_slru_cache(capacity: NonZeroUsize) -> SlruCache<&'static str, i32> {
     let mut cache = SlruCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1, None);
-    cache.put("banana", 2, None);
-    cache.put("cherry", 3, None);
+    cache.put("apple", 1, 1);
+    cache.put("banana", 2, 1);
+    cache.put("cherry", 3, 1);
 
     // Access patterns (will cause promotions)
     cache.get(&"apple");
@@ -138,8 +138,8 @@ fn test_slru_cache(capacity: NonZeroUsize) -> SlruCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions
-    cache.put("date", 4, None);
-    cache.put("elderberry", 5, None);
+    cache.put("date", 4, 1);
+    cache.put("elderberry", 5, 1);
 
     println!("   ✅ SLRU test completed");
     cache
@@ -157,9 +157,9 @@ fn test_lfuda_cache(capacity: NonZeroUsize) -> LfudaCache<&'static str, i32> {
     let mut cache = LfudaCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1, None);
-    cache.put("banana", 2, None);
-    cache.put("cherry", 3, None);
+    cache.put("apple", 1, 1);
+    cache.put("banana", 2, 1);
+    cache.put("cherry", 3, 1);
 
     // Access patterns
     cache.get(&"apple");
@@ -171,8 +171,8 @@ fn test_lfuda_cache(capacity: NonZeroUsize) -> LfudaCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions (will trigger aging)
-    cache.put("date", 4, None);
-    cache.put("elderberry", 5, None);
+    cache.put("date", 4, 1);
+    cache.put("elderberry", 5, 1);
 
     println!("   ✅ LFUDA test completed");
     cache
@@ -190,9 +190,9 @@ fn test_gdsf_cache(capacity: NonZeroUsize) -> GdsfCache<&'static str, i32> {
     let mut cache = GdsfCache::init(config, None);
 
     // Standard workload (with different sizes)
-    cache.put("apple", 1, Some(10)); // Small item
-    cache.put("banana", 2, Some(50)); // Large item
-    cache.put("cherry", 3, Some(25)); // Medium item
+    cache.put("apple", 1, 10); // Small item
+    cache.put("banana", 2, 50); // Large item
+    cache.put("cherry", 3, 25); // Medium item
 
     // Access patterns
     cache.get(&"apple");
@@ -204,8 +204,8 @@ fn test_gdsf_cache(capacity: NonZeroUsize) -> GdsfCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions
-    cache.put("date", 4, Some(15));
-    cache.put("elderberry", 5, Some(40));
+    cache.put("date", 4, 15);
+    cache.put("elderberry", 5, 40);
 
     println!("   ✅ GDSF test completed");
     cache

--- a/examples/metrics_demo.rs
+++ b/examples/metrics_demo.rs
@@ -59,9 +59,9 @@ fn test_lru_cache(capacity: NonZeroUsize) -> LruCache<&'static str, i32> {
     let mut cache = LruCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1);
-    cache.put("banana", 2);
-    cache.put("cherry", 3);
+    cache.put("apple", 1, None);
+    cache.put("banana", 2, None);
+    cache.put("cherry", 3, None);
 
     // Access patterns (apple becomes most recently used)
     cache.get(&"apple");
@@ -73,8 +73,8 @@ fn test_lru_cache(capacity: NonZeroUsize) -> LruCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions (will trigger evictions)
-    cache.put("date", 4);
-    cache.put("elderberry", 5);
+    cache.put("date", 4, None);
+    cache.put("elderberry", 5, None);
 
     println!("   ✅ LRU test completed");
     cache
@@ -91,9 +91,9 @@ fn test_lfu_cache(capacity: NonZeroUsize) -> LfuCache<&'static str, i32> {
     let mut cache = LfuCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1);
-    cache.put("banana", 2);
-    cache.put("cherry", 3);
+    cache.put("apple", 1, None);
+    cache.put("banana", 2, None);
+    cache.put("cherry", 3, None);
 
     // Access patterns (apple becomes most frequently used)
     cache.get(&"apple");
@@ -105,8 +105,8 @@ fn test_lfu_cache(capacity: NonZeroUsize) -> LfuCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions
-    cache.put("date", 4);
-    cache.put("elderberry", 5);
+    cache.put("date", 4, None);
+    cache.put("elderberry", 5, None);
 
     println!("   ✅ LFU test completed");
     cache
@@ -124,9 +124,9 @@ fn test_slru_cache(capacity: NonZeroUsize) -> SlruCache<&'static str, i32> {
     let mut cache = SlruCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1);
-    cache.put("banana", 2);
-    cache.put("cherry", 3);
+    cache.put("apple", 1, None);
+    cache.put("banana", 2, None);
+    cache.put("cherry", 3, None);
 
     // Access patterns (will cause promotions)
     cache.get(&"apple");
@@ -138,8 +138,8 @@ fn test_slru_cache(capacity: NonZeroUsize) -> SlruCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions
-    cache.put("date", 4);
-    cache.put("elderberry", 5);
+    cache.put("date", 4, None);
+    cache.put("elderberry", 5, None);
 
     println!("   ✅ SLRU test completed");
     cache
@@ -157,9 +157,9 @@ fn test_lfuda_cache(capacity: NonZeroUsize) -> LfudaCache<&'static str, i32> {
     let mut cache = LfudaCache::init(config, None);
 
     // Standard workload
-    cache.put("apple", 1);
-    cache.put("banana", 2);
-    cache.put("cherry", 3);
+    cache.put("apple", 1, None);
+    cache.put("banana", 2, None);
+    cache.put("cherry", 3, None);
 
     // Access patterns
     cache.get(&"apple");
@@ -171,8 +171,8 @@ fn test_lfuda_cache(capacity: NonZeroUsize) -> LfudaCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions (will trigger aging)
-    cache.put("date", 4);
-    cache.put("elderberry", 5);
+    cache.put("date", 4, None);
+    cache.put("elderberry", 5, None);
 
     println!("   ✅ LFUDA test completed");
     cache
@@ -190,9 +190,9 @@ fn test_gdsf_cache(capacity: NonZeroUsize) -> GdsfCache<&'static str, i32> {
     let mut cache = GdsfCache::init(config, None);
 
     // Standard workload (with different sizes)
-    cache.put("apple", 1, 10); // Small item
-    cache.put("banana", 2, 50); // Large item
-    cache.put("cherry", 3, 25); // Medium item
+    cache.put("apple", 1, Some(10)); // Small item
+    cache.put("banana", 2, Some(50)); // Large item
+    cache.put("cherry", 3, Some(25)); // Medium item
 
     // Access patterns
     cache.get(&"apple");
@@ -204,8 +204,8 @@ fn test_gdsf_cache(capacity: NonZeroUsize) -> GdsfCache<&'static str, i32> {
     cache.record_miss(32);
 
     // More insertions
-    cache.put("date", 4, 15);
-    cache.put("elderberry", 5, 40);
+    cache.put("date", 4, Some(15));
+    cache.put("elderberry", 5, Some(40));
 
     println!("   ✅ GDSF test completed");
     cache

--- a/src/concurrent/gdsf.rs
+++ b/src/concurrent/gdsf.rs
@@ -161,7 +161,7 @@
 //!
 //! // Insert small frequently-accessed items
 //! for i in 0..100 {
-//!     cache.put(format!("small-{}", i, None), vec![0u8; 1024], 1024);
+//!     cache.put(format!("small-{}", i), vec![0u8; 1024], Some(1024));
 //!     // Access multiple times to increase frequency
 //!     for _ in 0..5 {
 //!         let _ = cache.get(&format!("small-{}", i));

--- a/src/concurrent/gdsf.rs
+++ b/src/concurrent/gdsf.rs
@@ -57,10 +57,10 @@
 //!
 //! ```rust,ignore
 //! // Standard caches
-//! lru_cache.put(key, value);
+//! lru_cache.put(key, value, None);
 //!
 //! // GDSF requires size
-//! gdsf_cache.put(key, value, 2048);  // size in bytes
+//! gdsf_cache.put(key, value, Some(2048));  // size in bytes
 //! ```
 //!
 //! # Performance Characteristics
@@ -161,7 +161,7 @@
 //!
 //! // Insert small frequently-accessed items
 //! for i in 0..100 {
-//!     cache.put(format!("small-{}", i), vec![0u8; 1024], 1024);
+//!     cache.put(format!("small-{}", i, None), vec![0u8; 1024], 1024);
 //!     // Access multiple times to increase frequency
 //!     for _ in 0..5 {
 //!         let _ = cache.get(&format!("small-{}", i));
@@ -169,7 +169,7 @@
 //! }
 //!
 //! // Insert large item - may evict multiple small items based on priority
-//! cache.put("large".to_string(), vec![0u8; 5 * 1024 * 1024], 5 * 1024 * 1024);
+//! cache.put("large".to_string(), vec![0u8; 5 * 1024 * 1024], Some(5 * 1024 * 1024));
 //!
 //! // GDSF may choose to keep small popular items over one large item
 //! ```
@@ -327,9 +327,11 @@ where
 
     /// Inserts a key-value pair with its size into the cache.
     ///
-    /// Unlike other caches, GDSF requires the size of the object for priority calculation.
+    /// Inserts a key-value pair into the cache with optional size tracking.
+    ///
+    /// GDSF uses size for priority calculation. If `size` is `None`, defaults to 1.
     /// Returns the old value if the key was already present.
-    pub fn put(&self, key: K, value: V, size: u64) -> Option<V>
+    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<V>
     where
         K: Clone,
     {
@@ -559,8 +561,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, 100u64);
-        cache.put("b".to_string(), 2, 200u64);
+        cache.put("a".to_string(), 1, Some(100u64));
+        cache.put("b".to_string(), 2, Some(200u64));
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -581,7 +583,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let size = (10 + (i % 100)) as u64;
-                    cache.put(key.clone(), i, size);
+                    cache.put(key.clone(), i, Some(size));
                     let _ = cache.get(&key);
                 }
             }));
@@ -621,11 +623,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1, 100);
+        cache.put("key1".to_string(), 1, Some(100));
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2, 200);
+        cache.put("key2".to_string(), 2, Some(200));
         assert_eq!(cache.len(), 2);
     }
 
@@ -634,8 +636,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("key1".to_string(), 1, 100);
-        cache.put("key2".to_string(), 2, 200);
+        cache.put("key1".to_string(), 1, Some(100));
+        cache.put("key2".to_string(), 2, Some(200));
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -649,9 +651,9 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("key1".to_string(), 1, 100);
-        cache.put("key2".to_string(), 2, 200);
-        cache.put("key3".to_string(), 3, 300);
+        cache.put("key1".to_string(), 1, Some(100));
+        cache.put("key2".to_string(), 2, Some(200));
+        cache.put("key3".to_string(), 3, Some(300));
 
         assert_eq!(cache.len(), 3);
 
@@ -667,7 +669,7 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("exists".to_string(), 1, 100);
+        cache.put("exists".to_string(), 1, Some(100));
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -678,7 +680,7 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, String> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string(), 100);
+        cache.put("key".to_string(), "hello world".to_string(), Some(100));
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -693,9 +695,9 @@ mod tests {
             ConcurrentGdsfCache::init(make_config(1000, 16), None);
 
         // Add items with different sizes
-        cache.put("small".to_string(), 1, 100);
-        cache.put("medium".to_string(), 2, 500);
-        cache.put("large".to_string(), 3, 800);
+        cache.put("small".to_string(), 1, Some(100));
+        cache.put("medium".to_string(), 2, Some(500));
+        cache.put("large".to_string(), 3, Some(800));
 
         // Access small item multiple times
         for _ in 0..10 {
@@ -703,7 +705,7 @@ mod tests {
         }
 
         // Add more items to trigger eviction
-        cache.put("another".to_string(), 4, 200);
+        cache.put("another".to_string(), 4, Some(200));
 
         // Small item with high frequency should be retained
         assert!(!cache.is_empty());
@@ -717,7 +719,7 @@ mod tests {
         // Fill the cache with various sizes
         for i in 0..20 {
             let size = (100 + i * 50) as u64;
-            cache.put(std::format!("key{}", i), i, size);
+            cache.put(std::format!("key{}", i), i, Some(size));
         }
 
         // Cache size should be managed
@@ -729,8 +731,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, 100);
-        cache.put("b".to_string(), 2, 200);
+        cache.put("a".to_string(), 1, Some(100));
+        cache.put("b".to_string(), 2, Some(200));
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -762,7 +764,7 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("test_key".to_string(), 42, 100);
+        cache.put("test_key".to_string(), 42, Some(100));
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -777,10 +779,10 @@ mod tests {
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
         // Add items with various sizes
-        cache.put("tiny".to_string(), 1, 10);
-        cache.put("small".to_string(), 2, 100);
-        cache.put("medium".to_string(), 3, 500);
-        cache.put("large".to_string(), 4, 1000);
+        cache.put("tiny".to_string(), 1, Some(10));
+        cache.put("small".to_string(), 2, Some(100));
+        cache.put("medium".to_string(), 3, Some(500));
+        cache.put("large".to_string(), 4, Some(1000));
 
         // All items should be present
         assert_eq!(cache.len(), 4);
@@ -796,12 +798,12 @@ mod tests {
             ConcurrentGdsfCache::init(make_config(5000, 16), None);
 
         // Add large item
-        cache.put("large".to_string(), 1, 3000);
+        cache.put("large".to_string(), 1, Some(3000));
 
         // Add and frequently access small items
         for i in 0..10 {
             let key = std::format!("small{}", i);
-            cache.put(key.clone(), i, 100);
+            cache.put(key.clone(), i, Some(100));
             for _ in 0..5 {
                 let _ = cache.get(&key);
             }
@@ -816,8 +818,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, 100);
-        cache.put("b".to_string(), 2, 100);
+        cache.put("a".to_string(), 1, Some(100));
+        cache.put("b".to_string(), 2, Some(100));
 
         // contains() should check without updating priority
         assert!(cache.contains(&"a".to_string()));
@@ -830,8 +832,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, 100);
-        cache.put("b".to_string(), 2, 100);
+        cache.put("a".to_string(), 1, Some(100));
+        cache.put("b".to_string(), 2, Some(100));
 
         let initial_len = cache.len();
 
@@ -859,8 +861,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, 100);
-        cache.put("b".to_string(), 2, 100);
+        cache.put("a".to_string(), 1, Some(100));
+        cache.put("b".to_string(), 2, Some(100));
 
         let initial_len = cache.len();
 
@@ -888,9 +890,9 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, 100);
-        cache.put("b".to_string(), 2, 100);
-        cache.put("c".to_string(), 3, 100);
+        cache.put("a".to_string(), 1, Some(100));
+        cache.put("b".to_string(), 2, Some(100));
+        cache.put("c".to_string(), 3, Some(100));
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -909,11 +911,11 @@ mod tests {
 
         // GDSF priority = (frequency / size) + global_age
         // Insert entries with different sizes
-        cache.put("a".to_string(), 1, 100); // large
-        cache.put("b".to_string(), 2, 10); // small
-        cache.put("c".to_string(), 3, 50); // medium
-        cache.put("d".to_string(), 4, 10); // small
-        cache.put("e".to_string(), 5, 200); // very large
+        cache.put("a".to_string(), 1, Some(100)); // large
+        cache.put("b".to_string(), 2, Some(10)); // small
+        cache.put("c".to_string(), 3, Some(50)); // medium
+        cache.put("d".to_string(), 4, Some(10)); // small
+        cache.put("e".to_string(), 5, Some(200)); // very large
 
         // Access some entries to differentiate priorities
         cache.get(&"b".to_string()); // bump b frequency (small size = high priority)
@@ -931,7 +933,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry
-        cache.put("f".to_string(), 6, 30);
+        cache.put("f".to_string(), 6, Some(30));
         assert_eq!(cache.len(), 4);
 
         // Access "f" to increase its priority

--- a/src/concurrent/gdsf.rs
+++ b/src/concurrent/gdsf.rs
@@ -57,10 +57,10 @@
 //!
 //! ```rust,ignore
 //! // Standard caches
-//! lru_cache.put(key, value, None);
+//! lru_cache.put(key, value, 1);
 //!
 //! // GDSF requires size
-//! gdsf_cache.put(key, value, Some(2048));  // size in bytes
+//! gdsf_cache.put(key, value, 2048);  // size in bytes
 //! ```
 //!
 //! # Performance Characteristics
@@ -161,7 +161,7 @@
 //!
 //! // Insert small frequently-accessed items
 //! for i in 0..100 {
-//!     cache.put(format!("small-{}", i), vec![0u8; 1024], Some(1024));
+//!     cache.put(format!("small-{}", i), vec![0u8; 1024], 1024);
 //!     // Access multiple times to increase frequency
 //!     for _ in 0..5 {
 //!         let _ = cache.get(&format!("small-{}", i));
@@ -329,9 +329,9 @@ where
     ///
     /// Inserts a key-value pair into the cache with optional size tracking.
     ///
-    /// GDSF uses size for priority calculation. If `size` is `None`, defaults to 1.
+    /// GDSF uses size for priority calculation. Use `SIZE_UNIT` (1) for count-based caching.
     /// Returns the old value if the key was already present.
-    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<V>
+    pub fn put(&self, key: K, value: V, size: u64) -> Option<V>
     where
         K: Clone,
     {
@@ -561,8 +561,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, Some(100u64));
-        cache.put("b".to_string(), 2, Some(200u64));
+        cache.put("a".to_string(), 1, 100u64);
+        cache.put("b".to_string(), 2, 200u64);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -583,7 +583,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let size = (10 + (i % 100)) as u64;
-                    cache.put(key.clone(), i, Some(size));
+                    cache.put(key.clone(), i, size);
                     let _ = cache.get(&key);
                 }
             }));
@@ -623,11 +623,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1, Some(100));
+        cache.put("key1".to_string(), 1, 100);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2, Some(200));
+        cache.put("key2".to_string(), 2, 200);
         assert_eq!(cache.len(), 2);
     }
 
@@ -636,8 +636,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("key1".to_string(), 1, Some(100));
-        cache.put("key2".to_string(), 2, Some(200));
+        cache.put("key1".to_string(), 1, 100);
+        cache.put("key2".to_string(), 2, 200);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -651,9 +651,9 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("key1".to_string(), 1, Some(100));
-        cache.put("key2".to_string(), 2, Some(200));
-        cache.put("key3".to_string(), 3, Some(300));
+        cache.put("key1".to_string(), 1, 100);
+        cache.put("key2".to_string(), 2, 200);
+        cache.put("key3".to_string(), 3, 300);
 
         assert_eq!(cache.len(), 3);
 
@@ -669,7 +669,7 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("exists".to_string(), 1, Some(100));
+        cache.put("exists".to_string(), 1, 100);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -680,7 +680,7 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, String> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string(), Some(100));
+        cache.put("key".to_string(), "hello world".to_string(), 100);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -695,9 +695,9 @@ mod tests {
             ConcurrentGdsfCache::init(make_config(1000, 16), None);
 
         // Add items with different sizes
-        cache.put("small".to_string(), 1, Some(100));
-        cache.put("medium".to_string(), 2, Some(500));
-        cache.put("large".to_string(), 3, Some(800));
+        cache.put("small".to_string(), 1, 100);
+        cache.put("medium".to_string(), 2, 500);
+        cache.put("large".to_string(), 3, 800);
 
         // Access small item multiple times
         for _ in 0..10 {
@@ -705,7 +705,7 @@ mod tests {
         }
 
         // Add more items to trigger eviction
-        cache.put("another".to_string(), 4, Some(200));
+        cache.put("another".to_string(), 4, 200);
 
         // Small item with high frequency should be retained
         assert!(!cache.is_empty());
@@ -719,7 +719,7 @@ mod tests {
         // Fill the cache with various sizes
         for i in 0..20 {
             let size = (100 + i * 50) as u64;
-            cache.put(std::format!("key{}", i), i, Some(size));
+            cache.put(std::format!("key{}", i), i, size);
         }
 
         // Cache size should be managed
@@ -731,8 +731,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, Some(100));
-        cache.put("b".to_string(), 2, Some(200));
+        cache.put("a".to_string(), 1, 100);
+        cache.put("b".to_string(), 2, 200);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -764,7 +764,7 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("test_key".to_string(), 42, Some(100));
+        cache.put("test_key".to_string(), 42, 100);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -779,10 +779,10 @@ mod tests {
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
         // Add items with various sizes
-        cache.put("tiny".to_string(), 1, Some(10));
-        cache.put("small".to_string(), 2, Some(100));
-        cache.put("medium".to_string(), 3, Some(500));
-        cache.put("large".to_string(), 4, Some(1000));
+        cache.put("tiny".to_string(), 1, 10);
+        cache.put("small".to_string(), 2, 100);
+        cache.put("medium".to_string(), 3, 500);
+        cache.put("large".to_string(), 4, 1000);
 
         // All items should be present
         assert_eq!(cache.len(), 4);
@@ -798,12 +798,12 @@ mod tests {
             ConcurrentGdsfCache::init(make_config(5000, 16), None);
 
         // Add large item
-        cache.put("large".to_string(), 1, Some(3000));
+        cache.put("large".to_string(), 1, 3000);
 
         // Add and frequently access small items
         for i in 0..10 {
             let key = std::format!("small{}", i);
-            cache.put(key.clone(), i, Some(100));
+            cache.put(key.clone(), i, 100);
             for _ in 0..5 {
                 let _ = cache.get(&key);
             }
@@ -818,8 +818,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, Some(100));
-        cache.put("b".to_string(), 2, Some(100));
+        cache.put("a".to_string(), 1, 100);
+        cache.put("b".to_string(), 2, 100);
 
         // contains() should check without updating priority
         assert!(cache.contains(&"a".to_string()));
@@ -832,8 +832,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, Some(100));
-        cache.put("b".to_string(), 2, Some(100));
+        cache.put("a".to_string(), 1, 100);
+        cache.put("b".to_string(), 2, 100);
 
         let initial_len = cache.len();
 
@@ -861,8 +861,8 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, Some(100));
-        cache.put("b".to_string(), 2, Some(100));
+        cache.put("a".to_string(), 1, 100);
+        cache.put("b".to_string(), 2, 100);
 
         let initial_len = cache.len();
 
@@ -890,9 +890,9 @@ mod tests {
         let cache: ConcurrentGdsfCache<String, i32> =
             ConcurrentGdsfCache::init(make_config(10000, 16), None);
 
-        cache.put("a".to_string(), 1, Some(100));
-        cache.put("b".to_string(), 2, Some(100));
-        cache.put("c".to_string(), 3, Some(100));
+        cache.put("a".to_string(), 1, 100);
+        cache.put("b".to_string(), 2, 100);
+        cache.put("c".to_string(), 3, 100);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -911,11 +911,11 @@ mod tests {
 
         // GDSF priority = (frequency / size) + global_age
         // Insert entries with different sizes
-        cache.put("a".to_string(), 1, Some(100)); // large
-        cache.put("b".to_string(), 2, Some(10)); // small
-        cache.put("c".to_string(), 3, Some(50)); // medium
-        cache.put("d".to_string(), 4, Some(10)); // small
-        cache.put("e".to_string(), 5, Some(200)); // very large
+        cache.put("a".to_string(), 1, 100); // large
+        cache.put("b".to_string(), 2, 10); // small
+        cache.put("c".to_string(), 3, 50); // medium
+        cache.put("d".to_string(), 4, 10); // small
+        cache.put("e".to_string(), 5, 200); // very large
 
         // Access some entries to differentiate priorities
         cache.get(&"b".to_string()); // bump b frequency (small size = high priority)
@@ -933,7 +933,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry
-        cache.put("f".to_string(), 6, Some(30));
+        cache.put("f".to_string(), 6, 30);
         assert_eq!(cache.len(), 4);
 
         // Access "f" to increase its priority

--- a/src/concurrent/lfu.rs
+++ b/src/concurrent/lfu.rs
@@ -85,7 +85,7 @@
 //!     thread::spawn(move || {
 //!         for j in 0..1000 {
 //!             let key = format!("key-{}-{}", i, j);
-//!             cache.put(key.clone(), j, None);
+//!             cache.put(key.clone(), j, 1);
 //!             // Access popular keys more frequently
 //!             if j % 10 == 0 {
 //!                 for _ in 0..5 {
@@ -238,8 +238,8 @@ where
     /// Inserts a key-value pair into the cache with optional size tracking.
     ///
     /// If the cache is at capacity, the least frequently used entry is evicted.
-    /// If `size` is `None`, defaults to 1.
-    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+    /// Use `SIZE_UNIT` (1) for count-based caching.
+    pub fn put(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
         segment.put(key, value, size)
@@ -464,8 +464,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -485,7 +485,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
-                    cache.put(key.clone(), i, None);
+                    cache.put(key.clone(), i, 1);
                     // Access multiple times to test frequency tracking
                     if i % 3 == 0 {
                         let _ = cache.get(&key);
@@ -529,11 +529,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1, None);
+        cache.put("key1".to_string(), 1, 1);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2, None);
+        cache.put("key2".to_string(), 2, 1);
         assert_eq!(cache.len(), 2);
     }
 
@@ -542,8 +542,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1, None);
-        cache.put("key2".to_string(), 2, None);
+        cache.put("key1".to_string(), 1, 1);
+        cache.put("key2".to_string(), 2, 1);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -557,9 +557,9 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1, None);
-        cache.put("key2".to_string(), 2, None);
-        cache.put("key3".to_string(), 3, None);
+        cache.put("key1".to_string(), 1, 1);
+        cache.put("key2".to_string(), 2, 1);
+        cache.put("key3".to_string(), 3, 1);
 
         assert_eq!(cache.len(), 3);
 
@@ -575,7 +575,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("exists".to_string(), 1, None);
+        cache.put("exists".to_string(), 1, 1);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -586,7 +586,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, String> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string(), None);
+        cache.put("key".to_string(), "hello world".to_string(), 1);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -600,9 +600,9 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         // Access "a" and "c" multiple times to increase frequency
         for _ in 0..5 {
@@ -611,7 +611,7 @@ mod tests {
         }
 
         // Add a new item
-        cache.put("d".to_string(), 4, None);
+        cache.put("d".to_string(), 4, 1);
 
         assert!(cache.len() <= 48);
     }
@@ -623,7 +623,7 @@ mod tests {
 
         // Fill the cache
         for i in 0..10 {
-            cache.put(std::format!("key{}", i), i, None);
+            cache.put(std::format!("key{}", i), i, 1);
         }
 
         // Cache should not exceed capacity
@@ -635,8 +635,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -668,7 +668,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("test_key".to_string(), 42, None);
+        cache.put("test_key".to_string(), 42, 1);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -682,7 +682,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), 1, None);
+        cache.put("key".to_string(), 1, 1);
 
         // Access the key multiple times
         for _ in 0..10 {
@@ -698,8 +698,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         // contains() should check without updating frequency
         assert!(cache.contains(&"a".to_string()));
@@ -712,8 +712,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let initial_len = cache.len();
 
@@ -741,8 +741,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let initial_len = cache.len();
 
@@ -770,9 +770,9 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -790,11 +790,11 @@ mod tests {
             ConcurrentLfuCache::init(make_config(100, 1), None);
 
         // Insert entries: all start with frequency 1
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
-        cache.put("d".to_string(), 4, None);
-        cache.put("e".to_string(), 5, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
+        cache.put("d".to_string(), 4, 1);
+        cache.put("e".to_string(), 5, 1);
 
         // Access some entries to differentiate frequencies
         // a: freq 3, b: freq 2, c: freq 1, d: freq 4, e: freq 1
@@ -814,7 +814,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f" with freq 1
-        cache.put("f".to_string(), 6, None);
+        cache.put("f".to_string(), 6, 1);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest freq (e with freq 1, older than f)

--- a/src/concurrent/lfu.rs
+++ b/src/concurrent/lfu.rs
@@ -85,7 +85,7 @@
 //!     thread::spawn(move || {
 //!         for j in 0..1000 {
 //!             let key = format!("key-{}-{}", i, j);
-//!             cache.put(key.clone(), j);
+//!             cache.put(key.clone(), j, None);
 //!             // Access popular keys more frequently
 //!             if j % 10 == 0 {
 //!                 for _ in 0..5 {
@@ -235,20 +235,14 @@ where
         segment.get(key).map(f)
     }
 
-    /// Inserts a key-value pair into the cache.
+    /// Inserts a key-value pair into the cache with optional size tracking.
     ///
     /// If the cache is at capacity, the least frequently used entry is evicted.
-    pub fn put(&self, key: K, value: V) -> Option<(K, V)> {
+    /// If `size` is `None`, defaults to 1.
+    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
-        segment.put(key, value)
-    }
-
-    /// Inserts a key-value pair with explicit size tracking.
-    pub fn put_with_size(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
-        let idx = self.segment_index(&key);
-        let mut segment = self.segments[idx].lock();
-        segment.put_with_size(key, value, size)
+        segment.put(key, value, size)
     }
 
     /// Removes a key from the cache, returning the value if it existed.
@@ -470,8 +464,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -491,7 +485,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
-                    cache.put(key.clone(), i);
+                    cache.put(key.clone(), i, None);
                     // Access multiple times to test frequency tracking
                     if i % 3 == 0 {
                         let _ = cache.get(&key);
@@ -535,11 +529,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1);
+        cache.put("key1".to_string(), 1, None);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2);
+        cache.put("key2".to_string(), 2, None);
         assert_eq!(cache.len(), 2);
     }
 
@@ -548,8 +542,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1);
-        cache.put("key2".to_string(), 2);
+        cache.put("key1".to_string(), 1, None);
+        cache.put("key2".to_string(), 2, None);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -563,9 +557,9 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1);
-        cache.put("key2".to_string(), 2);
-        cache.put("key3".to_string(), 3);
+        cache.put("key1".to_string(), 1, None);
+        cache.put("key2".to_string(), 2, None);
+        cache.put("key3".to_string(), 3, None);
 
         assert_eq!(cache.len(), 3);
 
@@ -581,7 +575,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("exists".to_string(), 1);
+        cache.put("exists".to_string(), 1, None);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -592,7 +586,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, String> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string());
+        cache.put("key".to_string(), "hello world".to_string(), None);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -606,9 +600,9 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         // Access "a" and "c" multiple times to increase frequency
         for _ in 0..5 {
@@ -617,7 +611,7 @@ mod tests {
         }
 
         // Add a new item
-        cache.put("d".to_string(), 4);
+        cache.put("d".to_string(), 4, None);
 
         assert!(cache.len() <= 48);
     }
@@ -629,7 +623,7 @@ mod tests {
 
         // Fill the cache
         for i in 0..10 {
-            cache.put(std::format!("key{}", i), i);
+            cache.put(std::format!("key{}", i), i, None);
         }
 
         // Cache should not exceed capacity
@@ -641,8 +635,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -674,7 +668,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("test_key".to_string(), 42);
+        cache.put("test_key".to_string(), 42, None);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -688,7 +682,7 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), 1);
+        cache.put("key".to_string(), 1, None);
 
         // Access the key multiple times
         for _ in 0..10 {
@@ -704,8 +698,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         // contains() should check without updating frequency
         assert!(cache.contains(&"a".to_string()));
@@ -718,8 +712,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let initial_len = cache.len();
 
@@ -747,8 +741,8 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let initial_len = cache.len();
 
@@ -776,9 +770,9 @@ mod tests {
         let cache: ConcurrentLfuCache<String, i32> =
             ConcurrentLfuCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -796,11 +790,11 @@ mod tests {
             ConcurrentLfuCache::init(make_config(100, 1), None);
 
         // Insert entries: all start with frequency 1
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
-        cache.put("d".to_string(), 4);
-        cache.put("e".to_string(), 5);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
+        cache.put("d".to_string(), 4, None);
+        cache.put("e".to_string(), 5, None);
 
         // Access some entries to differentiate frequencies
         // a: freq 3, b: freq 2, c: freq 1, d: freq 4, e: freq 1
@@ -820,7 +814,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f" with freq 1
-        cache.put("f".to_string(), 6);
+        cache.put("f".to_string(), 6, None);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest freq (e with freq 1, older than f)

--- a/src/concurrent/lfuda.rs
+++ b/src/concurrent/lfuda.rs
@@ -93,7 +93,7 @@
 //!
 //! // Phase 1: Establish initial popularity
 //! for i in 0..1000 {
-//!     cache.put(format!("old-{}", i, None), i);
+//!     cache.put(format!("old-{}", i), i, None);
 //!     for _ in 0..10 {
 //!         cache.get(&format!("old-{}", i));
 //!     }

--- a/src/concurrent/lfuda.rs
+++ b/src/concurrent/lfuda.rs
@@ -93,7 +93,7 @@
 //!
 //! // Phase 1: Establish initial popularity
 //! for i in 0..1000 {
-//!     cache.put(format!("old-{}", i), i, None);
+//!     cache.put(format!("old-{}", i), i, 1);
 //!     for _ in 0..10 {
 //!         cache.get(&format!("old-{}", i));
 //!     }
@@ -105,7 +105,7 @@
 //!     thread::spawn(move || {
 //!         for i in 0..5000 {
 //!             let key = format!("new-{}-{}", t, i);
-//!             cache.put(key.clone(), i as i32, None);
+//!             cache.put(key.clone(), i as i32, 1);
 //!             let _ = cache.get(&key);
 //!         }
 //!     })
@@ -270,8 +270,8 @@ where
     /// Inserts a key-value pair into the cache with optional size tracking.
     ///
     /// If the cache is at capacity, the entry with lowest priority (frequency + age) is evicted.
-    /// If `size` is `None`, defaults to 1.
-    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+    /// Use `SIZE_UNIT` (1) for count-based caching.
+    pub fn put(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
         segment.put(key, value, size)
@@ -498,8 +498,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -519,7 +519,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
-                    cache.put(key.clone(), i, None);
+                    cache.put(key.clone(), i, 1);
                     let _ = cache.get(&key);
                 }
             }));
@@ -559,11 +559,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1, None);
+        cache.put("key1".to_string(), 1, 1);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2, None);
+        cache.put("key2".to_string(), 2, 1);
         assert_eq!(cache.len(), 2);
     }
 
@@ -572,8 +572,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1, None);
-        cache.put("key2".to_string(), 2, None);
+        cache.put("key1".to_string(), 1, 1);
+        cache.put("key2".to_string(), 2, 1);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -587,9 +587,9 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1, None);
-        cache.put("key2".to_string(), 2, None);
-        cache.put("key3".to_string(), 3, None);
+        cache.put("key1".to_string(), 1, 1);
+        cache.put("key2".to_string(), 2, 1);
+        cache.put("key3".to_string(), 3, 1);
 
         assert_eq!(cache.len(), 3);
 
@@ -605,7 +605,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("exists".to_string(), 1, None);
+        cache.put("exists".to_string(), 1, 1);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -616,7 +616,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, String> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string(), None);
+        cache.put("key".to_string(), "hello world".to_string(), 1);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -630,9 +630,9 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         // Access "a" and "c" multiple times to increase frequency
         for _ in 0..5 {
@@ -641,7 +641,7 @@ mod tests {
         }
 
         // Add a new item, aging should adjust priorities
-        cache.put("d".to_string(), 4, None);
+        cache.put("d".to_string(), 4, 1);
 
         assert!(cache.len() <= 48);
     }
@@ -653,7 +653,7 @@ mod tests {
 
         // Fill the cache
         for i in 0..10 {
-            cache.put(std::format!("key{}", i), i, None);
+            cache.put(std::format!("key{}", i), i, 1);
         }
 
         // Cache should not exceed capacity
@@ -665,8 +665,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -698,7 +698,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("test_key".to_string(), 42, None);
+        cache.put("test_key".to_string(), 42, 1);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -712,7 +712,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), 1, None);
+        cache.put("key".to_string(), 1, 1);
 
         // Access the key multiple times
         for _ in 0..10 {
@@ -730,7 +730,7 @@ mod tests {
 
         // Add items with different access patterns
         for i in 0..5 {
-            cache.put(std::format!("key{}", i), i, None);
+            cache.put(std::format!("key{}", i), i, 1);
             for _ in 0..i {
                 let _ = cache.get(&std::format!("key{}", i));
             }
@@ -738,7 +738,7 @@ mod tests {
 
         // Add more items to trigger eviction with aging
         for i in 5..10 {
-            cache.put(std::format!("key{}", i), i, None);
+            cache.put(std::format!("key{}", i), i, 1);
         }
 
         assert!(cache.len() <= 80);
@@ -749,8 +749,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         // contains() should check without updating priority
         assert!(cache.contains(&"a".to_string()));
@@ -763,8 +763,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let initial_len = cache.len();
 
@@ -792,8 +792,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let initial_len = cache.len();
 
@@ -821,9 +821,9 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -841,11 +841,11 @@ mod tests {
             ConcurrentLfudaCache::init(make_config(100, 1), None);
 
         // Insert entries: all start with initial priority
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
-        cache.put("d".to_string(), 4, None);
-        cache.put("e".to_string(), 5, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
+        cache.put("d".to_string(), 4, 1);
+        cache.put("e".to_string(), 5, 1);
 
         // Access some entries to differentiate priorities
         cache.get(&"a".to_string());
@@ -865,7 +865,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f"
-        cache.put("f".to_string(), 6, None);
+        cache.put("f".to_string(), 6, 1);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest priority

--- a/src/concurrent/lfuda.rs
+++ b/src/concurrent/lfuda.rs
@@ -93,7 +93,7 @@
 //!
 //! // Phase 1: Establish initial popularity
 //! for i in 0..1000 {
-//!     cache.put(format!("old-{}", i), i);
+//!     cache.put(format!("old-{}", i, None), i);
 //!     for _ in 0..10 {
 //!         cache.get(&format!("old-{}", i));
 //!     }
@@ -105,7 +105,7 @@
 //!     thread::spawn(move || {
 //!         for i in 0..5000 {
 //!             let key = format!("new-{}-{}", t, i);
-//!             cache.put(key.clone(), i as i32);
+//!             cache.put(key.clone(), i as i32, None);
 //!             let _ = cache.get(&key);
 //!         }
 //!     })
@@ -267,20 +267,14 @@ where
         segment.get(key).map(f)
     }
 
-    /// Inserts a key-value pair into the cache.
+    /// Inserts a key-value pair into the cache with optional size tracking.
     ///
     /// If the cache is at capacity, the entry with lowest priority (frequency + age) is evicted.
-    pub fn put(&self, key: K, value: V) -> Option<(K, V)> {
+    /// If `size` is `None`, defaults to 1.
+    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
-        segment.put(key, value)
-    }
-
-    /// Inserts a key-value pair with explicit size tracking.
-    pub fn put_with_size(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
-        let idx = self.segment_index(&key);
-        let mut segment = self.segments[idx].lock();
-        segment.put_with_size(key, value, size)
+        segment.put(key, value, size)
     }
 
     /// Removes a key from the cache, returning the value if it existed.
@@ -504,8 +498,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -525,7 +519,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
-                    cache.put(key.clone(), i);
+                    cache.put(key.clone(), i, None);
                     let _ = cache.get(&key);
                 }
             }));
@@ -565,11 +559,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1);
+        cache.put("key1".to_string(), 1, None);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2);
+        cache.put("key2".to_string(), 2, None);
         assert_eq!(cache.len(), 2);
     }
 
@@ -578,8 +572,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1);
-        cache.put("key2".to_string(), 2);
+        cache.put("key1".to_string(), 1, None);
+        cache.put("key2".to_string(), 2, None);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -593,9 +587,9 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key1".to_string(), 1);
-        cache.put("key2".to_string(), 2);
-        cache.put("key3".to_string(), 3);
+        cache.put("key1".to_string(), 1, None);
+        cache.put("key2".to_string(), 2, None);
+        cache.put("key3".to_string(), 3, None);
 
         assert_eq!(cache.len(), 3);
 
@@ -611,7 +605,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("exists".to_string(), 1);
+        cache.put("exists".to_string(), 1, None);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -622,7 +616,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, String> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string());
+        cache.put("key".to_string(), "hello world".to_string(), None);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -636,9 +630,9 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         // Access "a" and "c" multiple times to increase frequency
         for _ in 0..5 {
@@ -647,7 +641,7 @@ mod tests {
         }
 
         // Add a new item, aging should adjust priorities
-        cache.put("d".to_string(), 4);
+        cache.put("d".to_string(), 4, None);
 
         assert!(cache.len() <= 48);
     }
@@ -659,7 +653,7 @@ mod tests {
 
         // Fill the cache
         for i in 0..10 {
-            cache.put(std::format!("key{}", i), i);
+            cache.put(std::format!("key{}", i), i, None);
         }
 
         // Cache should not exceed capacity
@@ -671,8 +665,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -704,7 +698,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("test_key".to_string(), 42);
+        cache.put("test_key".to_string(), 42, None);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -718,7 +712,7 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), 1);
+        cache.put("key".to_string(), 1, None);
 
         // Access the key multiple times
         for _ in 0..10 {
@@ -736,7 +730,7 @@ mod tests {
 
         // Add items with different access patterns
         for i in 0..5 {
-            cache.put(std::format!("key{}", i), i);
+            cache.put(std::format!("key{}", i), i, None);
             for _ in 0..i {
                 let _ = cache.get(&std::format!("key{}", i));
             }
@@ -744,7 +738,7 @@ mod tests {
 
         // Add more items to trigger eviction with aging
         for i in 5..10 {
-            cache.put(std::format!("key{}", i), i);
+            cache.put(std::format!("key{}", i), i, None);
         }
 
         assert!(cache.len() <= 80);
@@ -755,8 +749,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         // contains() should check without updating priority
         assert!(cache.contains(&"a".to_string()));
@@ -769,8 +763,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let initial_len = cache.len();
 
@@ -798,8 +792,8 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let initial_len = cache.len();
 
@@ -827,9 +821,9 @@ mod tests {
         let cache: ConcurrentLfudaCache<String, i32> =
             ConcurrentLfudaCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -847,11 +841,11 @@ mod tests {
             ConcurrentLfudaCache::init(make_config(100, 1), None);
 
         // Insert entries: all start with initial priority
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
-        cache.put("d".to_string(), 4);
-        cache.put("e".to_string(), 5);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
+        cache.put("d".to_string(), 4, None);
+        cache.put("e".to_string(), 5, None);
 
         // Access some entries to differentiate priorities
         cache.get(&"a".to_string());
@@ -871,7 +865,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f"
-        cache.put("f".to_string(), 6);
+        cache.put("f".to_string(), 6, None);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest priority

--- a/src/concurrent/lru.rs
+++ b/src/concurrent/lru.rs
@@ -143,7 +143,7 @@ use std::collections::hash_map::RandomState as DefaultHashBuilder;
 /// let cache = Arc::new(ConcurrentLruCache::new(1000));
 ///
 /// // Safe to use from multiple threads
-/// cache.put("key".to_string(), 42);
+/// cache.put("key".to_string(), 42, None);
 /// assert_eq!(cache.get(&"key".to_string()), Some(42));
 /// ```
 pub struct ConcurrentLruCache<K, V, S = DefaultHashBuilder> {
@@ -340,6 +340,7 @@ where
     ///
     /// If the key exists, the value is updated and moved to MRU position.
     /// If at capacity, the LRU entry in the target segment is evicted.
+    /// If `size` is `None`, defaults to 1.
     ///
     /// # Returns
     ///
@@ -349,35 +350,12 @@ where
     /// # Example
     ///
     /// ```rust,ignore
-    /// cache.put("key".to_string(), 42);
+    /// cache.put("key".to_string(), 42, None);
     /// ```
-    pub fn put(&self, key: K, value: V) -> Option<(K, V)> {
+    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
-        segment.put(key, value)
-    }
-
-    /// Inserts a key-value pair with explicit size tracking.
-    ///
-    /// Use this for size-aware caching. The size is used for `max_size` tracking
-    /// and eviction decisions.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The key to insert
-    /// * `value` - The value to cache
-    /// * `size` - Size of this entry (in your chosen unit)
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// let data = vec![0u8; 1024];
-    /// cache.put_with_size("file".to_string(), data, 1024);
-    /// ```
-    pub fn put_with_size(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
-        let idx = self.segment_index(&key);
-        let mut segment = self.segments[idx].lock();
-        segment.put_with_size(key, value, size)
+        segment.put(key, value, size)
     }
 
     /// Removes a key from the cache.
@@ -407,7 +385,7 @@ where
 
     /// Returns the current total size across all segments.
     ///
-    /// This is the sum of all `size` values from `put_with_size()` calls.
+    /// This is the sum of all `size` values from `put()` calls.
     pub fn current_size(&self) -> u64 {
         self.segments.iter().map(|s| s.lock().current_size()).sum()
     }
@@ -626,9 +604,9 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         assert_eq!(cache.len(), 3);
         assert!(!cache.is_empty());
@@ -644,7 +622,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, String> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string());
+        cache.put("key".to_string(), "hello world".to_string(), None);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -658,7 +636,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("counter".to_string(), 0);
+        cache.put("counter".to_string(), 0, None);
 
         cache.get_mut_with(&"counter".to_string(), |v: &mut i32| *v += 1);
         cache.get_mut_with(&"counter".to_string(), |v: &mut i32| *v += 1);
@@ -671,8 +649,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         assert_eq!(cache.remove(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"a".to_string()), None);
@@ -686,9 +664,9 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         assert_eq!(cache.len(), 3);
         cache.clear();
@@ -701,7 +679,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("exists".to_string(), 1);
+        cache.put("exists".to_string(), 1, None);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -721,7 +699,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("thread_{}_key_{}", t, i);
-                    cache.put(key.clone(), t * 1000 + i);
+                    cache.put(key.clone(), t * 1000 + i, None);
                     let _ = cache.get(&key);
                 }
             }));
@@ -751,7 +729,7 @@ mod tests {
 
                     match i % 4 {
                         0 => {
-                            cache.put(key, i);
+                            cache.put(key, i, None);
                         }
                         1 => {
                             let _ = cache.get(&key);
@@ -805,14 +783,14 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         assert_eq!(cache.len(), 3);
 
         // This should evict the LRU item
-        cache.put("d".to_string(), 4);
+        cache.put("d".to_string(), 4, None);
 
         assert!(cache.len() <= 48);
         assert!(cache.contains(&"d".to_string()));
@@ -823,10 +801,10 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), 1);
+        cache.put("key".to_string(), 1, None);
         assert_eq!(cache.get(&"key".to_string()), Some(1));
 
-        cache.put("key".to_string(), 2);
+        cache.put("key".to_string(), 2, None);
         assert_eq!(cache.get(&"key".to_string()), Some(2));
         assert_eq!(cache.len(), 1);
     }
@@ -836,15 +814,15 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         // Access "a" to make it recently used
         let _ = cache.get(&"a".to_string());
 
         // Add a new item
-        cache.put("d".to_string(), 4);
+        cache.put("d".to_string(), 4, None);
 
         assert!(cache.contains(&"a".to_string()));
         assert!(cache.contains(&"d".to_string()));
@@ -855,8 +833,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -896,10 +874,10 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(16, 16), None);
 
-        cache.put("a".to_string(), 1);
+        cache.put("a".to_string(), 1, None);
         assert!(!cache.is_empty());
 
-        cache.put("b".to_string(), 2);
+        cache.put("b".to_string(), 2, None);
         assert!(cache.len() <= 16);
     }
 
@@ -908,7 +886,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("test_key".to_string(), 42);
+        cache.put("test_key".to_string(), 42, None);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -930,8 +908,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         // contains() should check without promoting
         assert!(cache.contains(&"a".to_string()));
@@ -944,8 +922,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let initial_len = cache.len();
 
@@ -973,8 +951,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let initial_len = cache.len();
 
@@ -1002,9 +980,9 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -1022,11 +1000,11 @@ mod tests {
             ConcurrentLruCache::init(make_config(100, 1), None);
 
         // Initial state: a(LRU) -> b -> c -> d -> e(MRU)
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
-        cache.put("d".to_string(), 4);
-        cache.put("e".to_string(), 5);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
+        cache.put("d".to_string(), 4, None);
+        cache.put("e".to_string(), 5, None);
 
         // pop LRU: removes "a"
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -1040,7 +1018,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f": c(LRU) -> d -> e -> f(MRU)
-        cache.put("f".to_string(), 6);
+        cache.put("f".to_string(), 6, None);
         assert_eq!(cache.len(), 4);
 
         // pop LRU: removes "c"

--- a/src/concurrent/lru.rs
+++ b/src/concurrent/lru.rs
@@ -143,7 +143,7 @@ use std::collections::hash_map::RandomState as DefaultHashBuilder;
 /// let cache = Arc::new(ConcurrentLruCache::new(1000));
 ///
 /// // Safe to use from multiple threads
-/// cache.put("key".to_string(), 42, None);
+/// cache.put("key".to_string(), 42, 1);
 /// assert_eq!(cache.get(&"key".to_string()), Some(42));
 /// ```
 pub struct ConcurrentLruCache<K, V, S = DefaultHashBuilder> {
@@ -340,7 +340,7 @@ where
     ///
     /// If the key exists, the value is updated and moved to MRU position.
     /// If at capacity, the LRU entry in the target segment is evicted.
-    /// If `size` is `None`, defaults to 1.
+    /// Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Returns
     ///
@@ -350,9 +350,9 @@ where
     /// # Example
     ///
     /// ```rust,ignore
-    /// cache.put("key".to_string(), 42, None);
+    /// cache.put("key".to_string(), 42, 1);
     /// ```
-    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+    pub fn put(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
         segment.put(key, value, size)
@@ -604,9 +604,9 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         assert_eq!(cache.len(), 3);
         assert!(!cache.is_empty());
@@ -622,7 +622,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, String> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string(), None);
+        cache.put("key".to_string(), "hello world".to_string(), 1);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -636,7 +636,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("counter".to_string(), 0, None);
+        cache.put("counter".to_string(), 0, 1);
 
         cache.get_mut_with(&"counter".to_string(), |v: &mut i32| *v += 1);
         cache.get_mut_with(&"counter".to_string(), |v: &mut i32| *v += 1);
@@ -649,8 +649,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         assert_eq!(cache.remove(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"a".to_string()), None);
@@ -664,9 +664,9 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         assert_eq!(cache.len(), 3);
         cache.clear();
@@ -679,7 +679,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("exists".to_string(), 1, None);
+        cache.put("exists".to_string(), 1, 1);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -699,7 +699,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("thread_{}_key_{}", t, i);
-                    cache.put(key.clone(), t * 1000 + i, None);
+                    cache.put(key.clone(), t * 1000 + i, 1);
                     let _ = cache.get(&key);
                 }
             }));
@@ -729,7 +729,7 @@ mod tests {
 
                     match i % 4 {
                         0 => {
-                            cache.put(key, i, None);
+                            cache.put(key, i, 1);
                         }
                         1 => {
                             let _ = cache.get(&key);
@@ -783,14 +783,14 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         assert_eq!(cache.len(), 3);
 
         // This should evict the LRU item
-        cache.put("d".to_string(), 4, None);
+        cache.put("d".to_string(), 4, 1);
 
         assert!(cache.len() <= 48);
         assert!(cache.contains(&"d".to_string()));
@@ -801,10 +801,10 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("key".to_string(), 1, None);
+        cache.put("key".to_string(), 1, 1);
         assert_eq!(cache.get(&"key".to_string()), Some(1));
 
-        cache.put("key".to_string(), 2, None);
+        cache.put("key".to_string(), 2, 1);
         assert_eq!(cache.get(&"key".to_string()), Some(2));
         assert_eq!(cache.len(), 1);
     }
@@ -814,15 +814,15 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(48, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         // Access "a" to make it recently used
         let _ = cache.get(&"a".to_string());
 
         // Add a new item
-        cache.put("d".to_string(), 4, None);
+        cache.put("d".to_string(), 4, 1);
 
         assert!(cache.contains(&"a".to_string()));
         assert!(cache.contains(&"d".to_string()));
@@ -833,8 +833,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -874,10 +874,10 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(16, 16), None);
 
-        cache.put("a".to_string(), 1, None);
+        cache.put("a".to_string(), 1, 1);
         assert!(!cache.is_empty());
 
-        cache.put("b".to_string(), 2, None);
+        cache.put("b".to_string(), 2, 1);
         assert!(cache.len() <= 16);
     }
 
@@ -886,7 +886,7 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("test_key".to_string(), 42, None);
+        cache.put("test_key".to_string(), 42, 1);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -908,8 +908,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         // contains() should check without promoting
         assert!(cache.contains(&"a".to_string()));
@@ -922,8 +922,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let initial_len = cache.len();
 
@@ -951,8 +951,8 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let initial_len = cache.len();
 
@@ -980,9 +980,9 @@ mod tests {
         let cache: ConcurrentLruCache<String, i32> =
             ConcurrentLruCache::init(make_config(100, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         let mut count = 0;
         while cache.pop().is_some() {
@@ -1000,11 +1000,11 @@ mod tests {
             ConcurrentLruCache::init(make_config(100, 1), None);
 
         // Initial state: a(LRU) -> b -> c -> d -> e(MRU)
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
-        cache.put("d".to_string(), 4, None);
-        cache.put("e".to_string(), 5, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
+        cache.put("d".to_string(), 4, 1);
+        cache.put("e".to_string(), 5, 1);
 
         // pop LRU: removes "a"
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -1018,7 +1018,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f": c(LRU) -> d -> e -> f(MRU)
-        cache.put("f".to_string(), 6, None);
+        cache.put("f".to_string(), 6, 1);
         assert_eq!(cache.len(), 4);
 
         // pop LRU: removes "c"

--- a/src/concurrent/slru.rs
+++ b/src/concurrent/slru.rs
@@ -259,21 +259,14 @@ where
         segment.get(key).map(f)
     }
 
-    /// Inserts a key-value pair into the cache.
+    /// Inserts a key-value pair into the cache with optional size tracking.
     ///
     /// New items enter the probationary segment and are promoted to the protected
-    /// segment on subsequent access.
-    pub fn put(&self, key: K, value: V) -> Option<(K, V)> {
+    /// segment on subsequent access. If `size` is `None`, defaults to 1.
+    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
-        segment.put(key, value)
-    }
-
-    /// Inserts a key-value pair with explicit size tracking.
-    pub fn put_with_size(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
-        let idx = self.segment_index(&key);
-        let mut segment = self.segments[idx].lock();
-        segment.put_with_size(key, value, size)
+        segment.put(key, value, size)
     }
 
     /// Removes a key from the cache, returning the value if it existed.
@@ -501,8 +494,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -522,7 +515,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
-                    cache.put(key.clone(), i);
+                    cache.put(key.clone(), i, None);
                     let _ = cache.get(&key);
                 }
             }));
@@ -562,11 +555,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1);
+        cache.put("key1".to_string(), 1, None);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2);
+        cache.put("key2".to_string(), 2, None);
         assert_eq!(cache.len(), 2);
     }
 
@@ -575,8 +568,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("key1".to_string(), 1);
-        cache.put("key2".to_string(), 2);
+        cache.put("key1".to_string(), 1, None);
+        cache.put("key2".to_string(), 2, None);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -590,9 +583,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("key1".to_string(), 1);
-        cache.put("key2".to_string(), 2);
-        cache.put("key3".to_string(), 3);
+        cache.put("key1".to_string(), 1, None);
+        cache.put("key2".to_string(), 2, None);
+        cache.put("key3".to_string(), 3, None);
 
         assert_eq!(cache.len(), 3);
 
@@ -608,7 +601,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("exists".to_string(), 1);
+        cache.put("exists".to_string(), 1, None);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -619,7 +612,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, String> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string());
+        cache.put("key".to_string(), "hello world".to_string(), None);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -635,7 +628,7 @@ mod tests {
 
         // Fill the cache
         for i in 0..10 {
-            cache.put(std::format!("key{}", i), i);
+            cache.put(std::format!("key{}", i), i, None);
         }
 
         // Cache should not exceed capacity
@@ -647,7 +640,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(160, 80, 16), None);
 
-        cache.put("key".to_string(), 1);
+        cache.put("key".to_string(), 1, None);
 
         // Access multiple times to promote to protected segment
         for _ in 0..3 {
@@ -663,8 +656,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -696,7 +689,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("test_key".to_string(), 42);
+        cache.put("test_key".to_string(), 42, None);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -710,8 +703,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
 
         // contains() should check without promoting
         assert!(cache.contains(&"a".to_string()));
@@ -725,9 +718,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 1), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         // Pop returns LRU entry (oldest = "a")
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -750,9 +743,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 1), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         // Pop_r returns MRU entry (newest = "c")
         assert_eq!(cache.pop_r(), Some(("c".to_string(), 3)));
@@ -775,9 +768,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 1), None);
 
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
 
         // Pop all in LRU order
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -793,11 +786,11 @@ mod tests {
             ConcurrentSlruCache::init(make_config(10, 5, 1), None);
 
         // Insert entries: all start in probationary
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
-        cache.put("d".to_string(), 4);
-        cache.put("e".to_string(), 5);
+        cache.put("a".to_string(), 1, None);
+        cache.put("b".to_string(), 2, None);
+        cache.put("c".to_string(), 3, None);
+        cache.put("d".to_string(), 4, None);
+        cache.put("e".to_string(), 5, None);
 
         // pop() removes LRU from probationary: "a"
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -811,7 +804,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f"
-        cache.put("f".to_string(), 6);
+        cache.put("f".to_string(), 6, None);
         assert_eq!(cache.len(), 4);
 
         // Access "c" to promote it
@@ -825,7 +818,7 @@ mod tests {
         cache.remove(&"c".to_string());
 
         // Put and promote another entry
-        cache.put("g".to_string(), 7);
+        cache.put("g".to_string(), 7, None);
         cache.get(&"g".to_string());
 
         // Pop remaining entries alternating pop/pop_r

--- a/src/concurrent/slru.rs
+++ b/src/concurrent/slru.rs
@@ -262,8 +262,8 @@ where
     /// Inserts a key-value pair into the cache with optional size tracking.
     ///
     /// New items enter the probationary segment and are promoted to the protected
-    /// segment on subsequent access. If `size` is `None`, defaults to 1.
-    pub fn put(&self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+    /// segment on subsequent access. Use `SIZE_UNIT` (1) for count-based caching.
+    pub fn put(&self, key: K, value: V, size: u64) -> Option<(K, V)> {
         let idx = self.segment_index(&key);
         let mut segment = self.segments[idx].lock();
         segment.put(key, value, size)
@@ -494,8 +494,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         assert_eq!(cache.get(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"b".to_string()), Some(2));
@@ -515,7 +515,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
-                    cache.put(key.clone(), i, None);
+                    cache.put(key.clone(), i, 1);
                     let _ = cache.get(&key);
                 }
             }));
@@ -555,11 +555,11 @@ mod tests {
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
 
-        cache.put("key1".to_string(), 1, None);
+        cache.put("key1".to_string(), 1, 1);
         assert_eq!(cache.len(), 1);
         assert!(!cache.is_empty());
 
-        cache.put("key2".to_string(), 2, None);
+        cache.put("key2".to_string(), 2, 1);
         assert_eq!(cache.len(), 2);
     }
 
@@ -568,8 +568,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("key1".to_string(), 1, None);
-        cache.put("key2".to_string(), 2, None);
+        cache.put("key1".to_string(), 1, 1);
+        cache.put("key2".to_string(), 2, 1);
 
         assert_eq!(cache.remove(&"key1".to_string()), Some(1));
         assert_eq!(cache.len(), 1);
@@ -583,9 +583,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("key1".to_string(), 1, None);
-        cache.put("key2".to_string(), 2, None);
-        cache.put("key3".to_string(), 3, None);
+        cache.put("key1".to_string(), 1, 1);
+        cache.put("key2".to_string(), 2, 1);
+        cache.put("key3".to_string(), 3, 1);
 
         assert_eq!(cache.len(), 3);
 
@@ -601,7 +601,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("exists".to_string(), 1, None);
+        cache.put("exists".to_string(), 1, 1);
 
         assert!(cache.contains(&"exists".to_string()));
         assert!(!cache.contains(&"missing".to_string()));
@@ -612,7 +612,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, String> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("key".to_string(), "hello world".to_string(), None);
+        cache.put("key".to_string(), "hello world".to_string(), 1);
 
         let len = cache.get_with(&"key".to_string(), |v: &String| v.len());
         assert_eq!(len, Some(11));
@@ -628,7 +628,7 @@ mod tests {
 
         // Fill the cache
         for i in 0..10 {
-            cache.put(std::format!("key{}", i), i, None);
+            cache.put(std::format!("key{}", i), i, 1);
         }
 
         // Cache should not exceed capacity
@@ -640,7 +640,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(160, 80, 16), None);
 
-        cache.put("key".to_string(), 1, None);
+        cache.put("key".to_string(), 1, 1);
 
         // Access multiple times to promote to protected segment
         for _ in 0..3 {
@@ -656,8 +656,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         let metrics = cache.metrics();
         // Metrics aggregation across segments
@@ -689,7 +689,7 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("test_key".to_string(), 42, None);
+        cache.put("test_key".to_string(), 42, 1);
 
         // Test with borrowed key
         let key_str = "test_key";
@@ -703,8 +703,8 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 16), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
 
         // contains() should check without promoting
         assert!(cache.contains(&"a".to_string()));
@@ -718,9 +718,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 1), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         // Pop returns LRU entry (oldest = "a")
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -743,9 +743,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 1), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         // Pop_r returns MRU entry (newest = "c")
         assert_eq!(cache.pop_r(), Some(("c".to_string(), 3)));
@@ -768,9 +768,9 @@ mod tests {
         let cache: ConcurrentSlruCache<String, i32> =
             ConcurrentSlruCache::init(make_config(100, 50, 1), None);
 
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
 
         // Pop all in LRU order
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -786,11 +786,11 @@ mod tests {
             ConcurrentSlruCache::init(make_config(10, 5, 1), None);
 
         // Insert entries: all start in probationary
-        cache.put("a".to_string(), 1, None);
-        cache.put("b".to_string(), 2, None);
-        cache.put("c".to_string(), 3, None);
-        cache.put("d".to_string(), 4, None);
-        cache.put("e".to_string(), 5, None);
+        cache.put("a".to_string(), 1, 1);
+        cache.put("b".to_string(), 2, 1);
+        cache.put("c".to_string(), 3, 1);
+        cache.put("d".to_string(), 4, 1);
+        cache.put("e".to_string(), 5, 1);
 
         // pop() removes LRU from probationary: "a"
         assert_eq!(cache.pop(), Some(("a".to_string(), 1)));
@@ -804,7 +804,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f"
-        cache.put("f".to_string(), 6, None);
+        cache.put("f".to_string(), 6, 1);
         assert_eq!(cache.len(), 4);
 
         // Access "c" to promote it
@@ -818,7 +818,7 @@ mod tests {
         cache.remove(&"c".to_string());
 
         // Put and promote another entry
-        cache.put("g".to_string(), 7, None);
+        cache.put("g".to_string(), 7, 1);
         cache.get(&"g".to_string());
 
         // Pop remaining entries alternating pop/pop_r

--- a/src/gdsf.rs
+++ b/src/gdsf.rs
@@ -156,10 +156,10 @@
 //!
 //! // Insert with explicit size tracking
 //! let small_data = vec![0u8; 1024];  // 1KB
-//! cache.put("small.txt".to_string(), small_data, Some(1024));
+//! cache.put("small.txt".to_string(), small_data, 1024);
 //!
 //! let large_data = vec![0u8; 1024 * 1024];  // 1MB
-//! cache.put("large.bin".to_string(), large_data, Some(1024 * 1024));
+//! cache.put("large.bin".to_string(), large_data, 1024 * 1024);
 //!
 //! // Small items get higher priority per byte
 //! assert!(cache.get(&"small.txt".to_string()).is_some());
@@ -183,7 +183,7 @@
 //! // Cache various asset types with their sizes
 //! fn cache_asset(cache: &mut GdsfCache<String, Vec<u8>>, url: &str, data: Vec<u8>) {
 //!     let size = data.len() as u64;
-//!     cache.put(url.to_string(), data, Some(size));
+//!     cache.put(url.to_string(), data, size);
 //! }
 //!
 //! // Small, frequently-accessed assets get priority over large, rarely-used ones
@@ -498,11 +498,10 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
         }
     }
 
-    pub(crate) fn put(&mut self, key: K, val: V, size: Option<u64>) -> Option<V>
+    pub(crate) fn put(&mut self, key: K, val: V, size: u64) -> Option<V>
     where
         K: Clone,
     {
-        let size = size.unwrap_or(1);
         if size == 0 {
             return None;
         }
@@ -872,7 +871,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `val` - The value to insert
-    /// * `size` - Optional size in bytes. If `None`, defaults to 1.
+    /// * `size` - Optional size in bytes. Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Multi-eviction behavior
     ///
@@ -881,7 +880,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     /// previously-associated entry is returned (not evicted entries).
     /// All evicted entries are counted in the `evictions` metric.
     #[inline]
-    pub fn put(&mut self, key: K, val: V, size: Option<u64>) -> Option<V>
+    pub fn put(&mut self, key: K, val: V, size: u64) -> Option<V>
     where
         K: Clone,
     {
@@ -925,8 +924,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = GdsfCache::init(config, None);
-    /// cache.put("a", 1, Some(10));
-    /// cache.put("b", 2, Some(10));
+    /// cache.put("a", 1, 10);
+    /// cache.put("b", 2, 10);
     ///
     /// // contains() does NOT update priority
     /// assert!(cache.contains(&"a"));
@@ -958,7 +957,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = GdsfCache::init(config, None);
-    /// cache.put("a", 1, Some(1));
+    /// cache.put("a", 1, 1);
     ///
     /// // peek does not change priority
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -993,8 +992,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = GdsfCache::init(config, None);
-    /// cache.put("a", 1, Some(10));
-    /// cache.put("b", 2, Some(20));
+    /// cache.put("a", 1, 10);
+    /// cache.put("b", 2, 20);
     /// cache.get(&"b"); // Increase priority of "b"
     ///
     /// // Pop the eviction candidate (lowest priority item)
@@ -1067,7 +1066,7 @@ impl<K: Hash + Eq, V: Clone> GdsfCache<K, V, DefaultHashBuilder> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: GdsfCache<&str, i32> = GdsfCache::init(config, None);
-    /// cache.put("key", 42, Some(1));
+    /// cache.put("key", 42, 1);
     ///
     /// // Cache with size limit (recommended for GDSF)
     /// let config = GdsfCacheConfig {
@@ -1104,9 +1103,9 @@ mod tests {
     fn test_gdsf_basic_operations() {
         let mut cache = make_cache(3);
 
-        assert_eq!(cache.put("a", 1, Some(1)), None);
-        assert_eq!(cache.put("b", 2, Some(2)), None);
-        assert_eq!(cache.put("c", 3, Some(1)), None);
+        assert_eq!(cache.put("a", 1, 1), None);
+        assert_eq!(cache.put("b", 2, 2), None);
+        assert_eq!(cache.put("c", 3, 1), None);
         assert_eq!(cache.len(), 3);
 
         assert_eq!(cache.get(&"a"), Some(1));
@@ -1121,13 +1120,13 @@ mod tests {
     fn test_gdsf_frequency_priority() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, Some(1));
-        cache.put("b", 2, Some(1));
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         cache.get(&"a");
         cache.get(&"a");
 
-        cache.put("c", 3, Some(1));
+        cache.put("c", 3, 1);
 
         assert!(cache.contains(&"a"));
         assert!(!cache.contains(&"b"));
@@ -1138,10 +1137,10 @@ mod tests {
     fn test_gdsf_size_consideration() {
         let mut cache = make_cache(2);
 
-        cache.put("small", 1, Some(1));
-        cache.put("large", 2, Some(10));
+        cache.put("small", 1, 1);
+        cache.put("large", 2, 10);
 
-        cache.put("medium", 3, Some(5));
+        cache.put("medium", 3, 5);
 
         assert!(cache.contains(&"small"));
         assert!(!cache.contains(&"large"));
@@ -1152,10 +1151,10 @@ mod tests {
     fn test_gdsf_update_existing() {
         let mut cache = make_cache(2);
 
-        cache.put("key", 1, Some(1));
+        cache.put("key", 1, 1);
         assert_eq!(cache.get(&"key"), Some(1));
 
-        assert_eq!(cache.put("key", 2, Some(2)), Some(1));
+        assert_eq!(cache.put("key", 2, 2), Some(1));
         assert_eq!(cache.get(&"key"), Some(2));
         assert_eq!(cache.len(), 1);
     }
@@ -1164,7 +1163,7 @@ mod tests {
     fn test_gdsf_zero_size_rejection() {
         let mut cache = make_cache(2);
 
-        assert_eq!(cache.put("key", 1, Some(0)), None);
+        assert_eq!(cache.put("key", 1, 0), None);
         assert_eq!(cache.len(), 0);
         assert!(!cache.contains(&"key"));
     }
@@ -1173,8 +1172,8 @@ mod tests {
     fn test_gdsf_remove_by_key_legacy() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, Some(1));
-        cache.put("b", 2, Some(1));
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Use remove() instead of the deprecated pop(key)
         assert_eq!(cache.remove(&"a"), Some(1));
@@ -1189,8 +1188,8 @@ mod tests {
     fn test_gdsf_clear() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, Some(1));
-        cache.put("b", 2, Some(1));
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
         assert_eq!(cache.len(), 2);
 
         cache.clear();
@@ -1204,12 +1203,12 @@ mod tests {
     fn test_gdsf_global_aging() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, Some(1));
-        cache.put("b", 2, Some(1));
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         let initial_age = cache.global_age();
 
-        cache.put("c", 3, Some(1));
+        cache.put("c", 3, 1);
 
         assert!(cache.global_age() > initial_age);
     }
@@ -1218,9 +1217,9 @@ mod tests {
     fn test_miri_stacked_borrows_fix() {
         let mut cache = make_cache(10);
 
-        cache.put("a", 1, Some(10));
-        cache.put("b", 2, Some(20));
-        cache.put("c", 3, Some(15));
+        cache.put("a", 1, 10);
+        cache.put("b", 2, 20);
+        cache.put("c", 3, 15);
 
         for _ in 0..3 {
             assert_eq!(cache.get(&"a"), Some(1));
@@ -1248,8 +1247,8 @@ mod tests {
         assert_eq!(segment.len(), 0);
         assert!(segment.is_empty());
         assert_eq!(segment.cap().get(), 2);
-        segment.put("a", 1, Some(1));
-        segment.put("b", 2, Some(2));
+        segment.put("a", 1, 1);
+        segment.put("b", 2, 2);
         assert_eq!(segment.len(), 2);
         assert_eq!(segment.get(&"a"), Some(1));
         assert_eq!(segment.get(&"b"), Some(2));
@@ -1275,7 +1274,7 @@ mod tests {
                     let key = std::format!("key_{}_{}", t, i);
                     let size = ((i % 10) + 1) as u64; // Varying sizes 1-10
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i, Some(size));
+                    guard.put(key.clone(), i, size);
                     let _ = guard.get(&key);
                 }
             }));
@@ -1298,9 +1297,9 @@ mod tests {
         assert_eq!(cache.max_size(), u64::MAX);
 
         // GDSF already requires size in put()
-        cache.put("a", 1, Some(100));
-        cache.put("b", 2, Some(200));
-        cache.put("c", 3, Some(150));
+        cache.put("a", 1, 100);
+        cache.put("b", 2, 200);
+        cache.put("c", 3, 150);
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1340,8 +1339,8 @@ mod tests {
     #[test]
     fn test_gdsf_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, Some(10));
-        cache.put("b", 2, Some(10));
+        cache.put("a", 1, 10);
+        cache.put("b", 2, 10);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1355,7 +1354,7 @@ mod tests {
         assert!(cache.contains(&"a"));
 
         // Adding "c" should evict "a" (lowest priority), not "b"
-        cache.put("c", 3, Some(10));
+        cache.put("c", 3, 10);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1364,9 +1363,9 @@ mod tests {
     #[test]
     fn test_gdsf_pop_returns_lowest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, Some(10));
-        cache.put("b", 2, Some(10));
-        cache.put("c", 3, Some(10));
+        cache.put("a", 1, 10);
+        cache.put("b", 2, 10);
+        cache.put("c", 3, 10);
 
         // Access "b" and "c" to increase their priorities
         cache.get(&"b");
@@ -1392,9 +1391,9 @@ mod tests {
     #[test]
     fn test_gdsf_pop_r_returns_highest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, Some(10));
-        cache.put("b", 2, Some(10));
-        cache.put("c", 3, Some(10));
+        cache.put("a", 1, 10);
+        cache.put("b", 2, 10);
+        cache.put("c", 3, 10);
 
         // Access items to build different priorities
         cache.get(&"b"); // "b" priority increases
@@ -1427,8 +1426,8 @@ mod tests {
     #[test]
     fn test_gdsf_pop_updates_global_age() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, Some(10));
-        cache.put("b", 2, Some(10));
+        cache.put("a", 1, 10);
+        cache.put("b", 2, 10);
 
         let initial_age = cache.global_age();
 
@@ -1452,7 +1451,7 @@ mod tests {
     #[test]
     fn test_gdsf_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, Some(10));
+        cache.put("a", 1, 10);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1462,7 +1461,7 @@ mod tests {
     #[test]
     fn test_gdsf_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, Some(10));
+        cache.put("a", 1, 10);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1472,8 +1471,8 @@ mod tests {
     #[test]
     fn test_gdsf_remove_by_key() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, Some(10));
-        cache.put("b", 2, Some(10));
+        cache.put("a", 1, 10);
+        cache.put("b", 2, 10);
 
         // remove() works like pop(key)
         assert_eq!(cache.remove(&"a"), Some(1));
@@ -1490,11 +1489,11 @@ mod tests {
 
         // GDSF priority = (frequency / size) + global_age
         // Insert entries with different sizes
-        cache.put("a", 1, Some(100)); // large
-        cache.put("b", 2, Some(10)); // small
-        cache.put("c", 3, Some(50)); // medium
-        cache.put("d", 4, Some(10)); // small
-        cache.put("e", 5, Some(200)); // very large
+        cache.put("a", 1, 100); // large
+        cache.put("b", 2, 10); // small
+        cache.put("c", 3, 50); // medium
+        cache.put("d", 4, 10); // small
+        cache.put("e", 5, 200); // very large
 
         // Access some entries to differentiate priorities
         cache.get(&"b"); // bump b frequency (small size = high priority)
@@ -1512,7 +1511,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry
-        cache.put("f", 6, Some(30));
+        cache.put("f", 6, 30);
         assert_eq!(cache.len(), 4);
 
         // Access "f" to increase its priority

--- a/src/gdsf.rs
+++ b/src/gdsf.rs
@@ -156,10 +156,10 @@
 //!
 //! // Insert with explicit size tracking
 //! let small_data = vec![0u8; 1024];  // 1KB
-//! cache.put("small.txt".to_string(), small_data, 1024);
+//! cache.put("small.txt".to_string(), small_data, Some(1024));
 //!
 //! let large_data = vec![0u8; 1024 * 1024];  // 1MB
-//! cache.put("large.bin".to_string(), large_data, 1024 * 1024);
+//! cache.put("large.bin".to_string(), large_data, Some(1024 * 1024));
 //!
 //! // Small items get higher priority per byte
 //! assert!(cache.get(&"small.txt".to_string()).is_some());
@@ -183,7 +183,7 @@
 //! // Cache various asset types with their sizes
 //! fn cache_asset(cache: &mut GdsfCache<String, Vec<u8>>, url: &str, data: Vec<u8>) {
 //!     let size = data.len() as u64;
-//!     cache.put(url.to_string(), data, size);
+//!     cache.put(url.to_string(), data, Some(size));
 //! }
 //!
 //! // Small, frequently-accessed assets get priority over large, rarely-used ones
@@ -277,7 +277,6 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
-use core::mem;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "hashbrown")]
@@ -376,10 +375,6 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
         &self.metrics
     }
 
-    fn estimate_object_size(&self, _key: &K, _value: &V) -> u64 {
-        mem::size_of::<K>() as u64 + mem::size_of::<V>() as u64 + 64
-    }
-
     #[inline]
     pub(crate) fn record_miss(&mut self, object_size: u64) {
         self.metrics.core.record_miss(object_size);
@@ -464,9 +459,9 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
             unsafe {
                 // SAFETY: node comes from our map
                 let entry = (*node).get_value();
-                let object_size = self.estimate_object_size(&entry.key, &entry.value);
+                let entry_size = entry.metadata.size;
                 let meta = &entry.metadata.algorithm;
-                self.metrics.core.record_hit(object_size);
+                self.metrics.core.record_hit(entry_size);
                 self.metrics
                     .record_item_access(meta.frequency, entry.metadata.size, meta.priority);
 
@@ -488,9 +483,9 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
             unsafe {
                 // SAFETY: node comes from our map
                 let entry = (*node).get_value();
-                let object_size = self.estimate_object_size(&entry.key, &entry.value);
+                let entry_size = entry.metadata.size;
                 let meta = &entry.metadata.algorithm;
-                self.metrics.core.record_hit(object_size);
+                self.metrics.core.record_hit(entry_size);
                 self.metrics
                     .record_item_access(meta.frequency, entry.metadata.size, meta.priority);
 
@@ -503,15 +498,14 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
         }
     }
 
-    pub(crate) fn put(&mut self, key: K, val: V, size: u64) -> Option<V>
+    pub(crate) fn put(&mut self, key: K, val: V, size: Option<u64>) -> Option<V>
     where
         K: Clone,
     {
+        let size = size.unwrap_or(1);
         if size == 0 {
             return None;
         }
-
-        let object_size = self.estimate_object_size(&key, &val);
 
         // Check if key exists - update existing entry
         if let Some(&node) = self.map.get(&key) {
@@ -559,7 +553,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
 
                 if let Some(new_node) = list.add(new_entry) {
                     self.map.insert(key, new_node);
-                    self.metrics.core.record_insertion(object_size);
+                    self.metrics.core.record_insertion(size);
                     return Some(old_value);
                 } else {
                     self.map.remove(&key);
@@ -693,7 +687,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put_with_size()` operations.
+    /// entries to make room during `put()`/`put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop_eviction_candidate(&mut self) -> Option<(K, V)> {
@@ -874,6 +868,12 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     /// calculation (`priority = global_age + frequency / size`), favoring
     /// small, frequently-accessed items.
     ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `val` - The value to insert
+    /// * `size` - Optional size in bytes. If `None`, defaults to 1.
+    ///
     /// # Multi-eviction behavior
     ///
     /// When the new entry's size would exceed `max_size`, multiple existing
@@ -881,7 +881,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     /// previously-associated entry is returned (not evicted entries).
     /// All evicted entries are counted in the `evictions` metric.
     #[inline]
-    pub fn put(&mut self, key: K, val: V, size: u64) -> Option<V>
+    pub fn put(&mut self, key: K, val: V, size: Option<u64>) -> Option<V>
     where
         K: Clone,
     {
@@ -925,8 +925,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = GdsfCache::init(config, None);
-    /// cache.put("a", 1, 10);
-    /// cache.put("b", 2, 10);
+    /// cache.put("a", 1, Some(10));
+    /// cache.put("b", 2, Some(10));
     ///
     /// // contains() does NOT update priority
     /// assert!(cache.contains(&"a"));
@@ -958,7 +958,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = GdsfCache::init(config, None);
-    /// cache.put("a", 1, 1);
+    /// cache.put("a", 1, Some(1));
     ///
     /// // peek does not change priority
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -993,8 +993,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = GdsfCache::init(config, None);
-    /// cache.put("a", 1, 10);
-    /// cache.put("b", 2, 20);
+    /// cache.put("a", 1, Some(10));
+    /// cache.put("b", 2, Some(20));
     /// cache.get(&"b"); // Increase priority of "b"
     ///
     /// // Pop the eviction candidate (lowest priority item)
@@ -1067,7 +1067,7 @@ impl<K: Hash + Eq, V: Clone> GdsfCache<K, V, DefaultHashBuilder> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: GdsfCache<&str, i32> = GdsfCache::init(config, None);
-    /// cache.put("key", 42, 1);
+    /// cache.put("key", 42, Some(1));
     ///
     /// // Cache with size limit (recommended for GDSF)
     /// let config = GdsfCacheConfig {
@@ -1104,9 +1104,9 @@ mod tests {
     fn test_gdsf_basic_operations() {
         let mut cache = make_cache(3);
 
-        assert_eq!(cache.put("a", 1, 1), None);
-        assert_eq!(cache.put("b", 2, 2), None);
-        assert_eq!(cache.put("c", 3, 1), None);
+        assert_eq!(cache.put("a", 1, Some(1)), None);
+        assert_eq!(cache.put("b", 2, Some(2)), None);
+        assert_eq!(cache.put("c", 3, Some(1)), None);
         assert_eq!(cache.len(), 3);
 
         assert_eq!(cache.get(&"a"), Some(1));
@@ -1121,13 +1121,13 @@ mod tests {
     fn test_gdsf_frequency_priority() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, 1);
-        cache.put("b", 2, 1);
+        cache.put("a", 1, Some(1));
+        cache.put("b", 2, Some(1));
 
         cache.get(&"a");
         cache.get(&"a");
 
-        cache.put("c", 3, 1);
+        cache.put("c", 3, Some(1));
 
         assert!(cache.contains(&"a"));
         assert!(!cache.contains(&"b"));
@@ -1138,10 +1138,10 @@ mod tests {
     fn test_gdsf_size_consideration() {
         let mut cache = make_cache(2);
 
-        cache.put("small", 1, 1);
-        cache.put("large", 2, 10);
+        cache.put("small", 1, Some(1));
+        cache.put("large", 2, Some(10));
 
-        cache.put("medium", 3, 5);
+        cache.put("medium", 3, Some(5));
 
         assert!(cache.contains(&"small"));
         assert!(!cache.contains(&"large"));
@@ -1152,10 +1152,10 @@ mod tests {
     fn test_gdsf_update_existing() {
         let mut cache = make_cache(2);
 
-        cache.put("key", 1, 1);
+        cache.put("key", 1, Some(1));
         assert_eq!(cache.get(&"key"), Some(1));
 
-        assert_eq!(cache.put("key", 2, 2), Some(1));
+        assert_eq!(cache.put("key", 2, Some(2)), Some(1));
         assert_eq!(cache.get(&"key"), Some(2));
         assert_eq!(cache.len(), 1);
     }
@@ -1164,7 +1164,7 @@ mod tests {
     fn test_gdsf_zero_size_rejection() {
         let mut cache = make_cache(2);
 
-        assert_eq!(cache.put("key", 1, 0), None);
+        assert_eq!(cache.put("key", 1, Some(0)), None);
         assert_eq!(cache.len(), 0);
         assert!(!cache.contains(&"key"));
     }
@@ -1173,8 +1173,8 @@ mod tests {
     fn test_gdsf_remove_by_key_legacy() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, 1);
-        cache.put("b", 2, 1);
+        cache.put("a", 1, Some(1));
+        cache.put("b", 2, Some(1));
 
         // Use remove() instead of the deprecated pop(key)
         assert_eq!(cache.remove(&"a"), Some(1));
@@ -1189,8 +1189,8 @@ mod tests {
     fn test_gdsf_clear() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, 1);
-        cache.put("b", 2, 1);
+        cache.put("a", 1, Some(1));
+        cache.put("b", 2, Some(1));
         assert_eq!(cache.len(), 2);
 
         cache.clear();
@@ -1204,12 +1204,12 @@ mod tests {
     fn test_gdsf_global_aging() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, 1);
-        cache.put("b", 2, 1);
+        cache.put("a", 1, Some(1));
+        cache.put("b", 2, Some(1));
 
         let initial_age = cache.global_age();
 
-        cache.put("c", 3, 1);
+        cache.put("c", 3, Some(1));
 
         assert!(cache.global_age() > initial_age);
     }
@@ -1218,9 +1218,9 @@ mod tests {
     fn test_miri_stacked_borrows_fix() {
         let mut cache = make_cache(10);
 
-        cache.put("a", 1, 10);
-        cache.put("b", 2, 20);
-        cache.put("c", 3, 15);
+        cache.put("a", 1, Some(10));
+        cache.put("b", 2, Some(20));
+        cache.put("c", 3, Some(15));
 
         for _ in 0..3 {
             assert_eq!(cache.get(&"a"), Some(1));
@@ -1248,8 +1248,8 @@ mod tests {
         assert_eq!(segment.len(), 0);
         assert!(segment.is_empty());
         assert_eq!(segment.cap().get(), 2);
-        segment.put("a", 1, 1);
-        segment.put("b", 2, 2);
+        segment.put("a", 1, Some(1));
+        segment.put("b", 2, Some(2));
         assert_eq!(segment.len(), 2);
         assert_eq!(segment.get(&"a"), Some(1));
         assert_eq!(segment.get(&"b"), Some(2));
@@ -1275,7 +1275,7 @@ mod tests {
                     let key = std::format!("key_{}_{}", t, i);
                     let size = ((i % 10) + 1) as u64; // Varying sizes 1-10
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i, size);
+                    guard.put(key.clone(), i, Some(size));
                     let _ = guard.get(&key);
                 }
             }));
@@ -1298,9 +1298,9 @@ mod tests {
         assert_eq!(cache.max_size(), u64::MAX);
 
         // GDSF already requires size in put()
-        cache.put("a", 1, 100);
-        cache.put("b", 2, 200);
-        cache.put("c", 3, 150);
+        cache.put("a", 1, Some(100));
+        cache.put("b", 2, Some(200));
+        cache.put("c", 3, Some(150));
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1340,8 +1340,8 @@ mod tests {
     #[test]
     fn test_gdsf_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, 10);
-        cache.put("b", 2, 10);
+        cache.put("a", 1, Some(10));
+        cache.put("b", 2, Some(10));
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1355,7 +1355,7 @@ mod tests {
         assert!(cache.contains(&"a"));
 
         // Adding "c" should evict "a" (lowest priority), not "b"
-        cache.put("c", 3, 10);
+        cache.put("c", 3, Some(10));
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1364,9 +1364,9 @@ mod tests {
     #[test]
     fn test_gdsf_pop_returns_lowest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, 10);
-        cache.put("b", 2, 10);
-        cache.put("c", 3, 10);
+        cache.put("a", 1, Some(10));
+        cache.put("b", 2, Some(10));
+        cache.put("c", 3, Some(10));
 
         // Access "b" and "c" to increase their priorities
         cache.get(&"b");
@@ -1392,9 +1392,9 @@ mod tests {
     #[test]
     fn test_gdsf_pop_r_returns_highest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, 10);
-        cache.put("b", 2, 10);
-        cache.put("c", 3, 10);
+        cache.put("a", 1, Some(10));
+        cache.put("b", 2, Some(10));
+        cache.put("c", 3, Some(10));
 
         // Access items to build different priorities
         cache.get(&"b"); // "b" priority increases
@@ -1427,8 +1427,8 @@ mod tests {
     #[test]
     fn test_gdsf_pop_updates_global_age() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, 10);
-        cache.put("b", 2, 10);
+        cache.put("a", 1, Some(10));
+        cache.put("b", 2, Some(10));
 
         let initial_age = cache.global_age();
 
@@ -1452,7 +1452,7 @@ mod tests {
     #[test]
     fn test_gdsf_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, 10);
+        cache.put("a", 1, Some(10));
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1462,7 +1462,7 @@ mod tests {
     #[test]
     fn test_gdsf_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, 10);
+        cache.put("a", 1, Some(10));
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1472,8 +1472,8 @@ mod tests {
     #[test]
     fn test_gdsf_remove_by_key() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, 10);
-        cache.put("b", 2, 10);
+        cache.put("a", 1, Some(10));
+        cache.put("b", 2, Some(10));
 
         // remove() works like pop(key)
         assert_eq!(cache.remove(&"a"), Some(1));
@@ -1490,11 +1490,11 @@ mod tests {
 
         // GDSF priority = (frequency / size) + global_age
         // Insert entries with different sizes
-        cache.put("a", 1, 100); // large
-        cache.put("b", 2, 10); // small
-        cache.put("c", 3, 50); // medium
-        cache.put("d", 4, 10); // small
-        cache.put("e", 5, 200); // very large
+        cache.put("a", 1, Some(100)); // large
+        cache.put("b", 2, Some(10)); // small
+        cache.put("c", 3, Some(50)); // medium
+        cache.put("d", 4, Some(10)); // small
+        cache.put("e", 5, Some(200)); // very large
 
         // Access some entries to differentiate priorities
         cache.get(&"b"); // bump b frequency (small size = high priority)
@@ -1512,7 +1512,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry
-        cache.put("f", 6, 30);
+        cache.put("f", 6, Some(30));
         assert_eq!(cache.len(), 4);
 
         // Access "f" to increase its priority

--- a/src/gdsf.rs
+++ b/src/gdsf.rs
@@ -687,7 +687,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> GdsfSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put()` operations.
+    /// entries to make room during `put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop_eviction_candidate(&mut self) -> Option<(K, V)> {

--- a/src/lfu.rs
+++ b/src/lfu.rs
@@ -122,16 +122,16 @@
 //! };
 //! let mut cache = LfuCache::init(config, None);
 //!
-//! cache.put("a", 1, None);
-//! cache.put("b", 2, None);
-//! cache.put("c", 3, None);
+//! cache.put("a", 1, 1);
+//! cache.put("b", 2, 1);
+//! cache.put("c", 3, 1);
 //!
 //! // Access "a" multiple times - increases its frequency
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //!
 //! // Add new item - "b" or "c" evicted (both at frequency 1)
-//! cache.put("d", 4, None);
+//! cache.put("d", 4, 1);
 //!
 //! // "a" survives due to higher frequency
 //! assert_eq!(cache.get(&"a"), Some(&1));
@@ -152,7 +152,7 @@
 //! let mut cache: LfuCache<String, Vec<u8>> = LfuCache::init(config, None);
 //!
 //! let data = vec![0u8; 1024];  // 1KB
-//! cache.put("file.bin".to_string(), data.clone(), Some(1024));
+//! cache.put("file.bin".to_string(), data.clone(), 1024);
 //! ```
 
 extern crate alloc;
@@ -444,12 +444,11 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuSegment<K, V, S> {
     /// Insert a key-value pair with optional size tracking.
     ///
     /// The `size` parameter specifies how much of `max_size` this entry consumes.
-    /// If `None`, defaults to `1` for count-based caching.
-    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    /// Use `SIZE_UNIT` (1) for count-based caching for count-based caching.
+    pub(crate) fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         K: Clone,
     {
-        let size = size.unwrap_or(1);
         // If key already exists, update it
         if let Some(&node) = self.map.get(&key) {
             unsafe {
@@ -746,16 +745,16 @@ impl<K, V, S> core::fmt::Debug for LfuSegment<K, V, S> {
 /// let mut cache = LfuCache::init(config, None);
 ///
 /// // Add some items
-/// cache.put("a", 1, None);
-/// cache.put("b", 2, None);
-/// cache.put("c", 3, None);
+/// cache.put("a", 1, 1);
+/// cache.put("b", 2, 1);
+/// cache.put("c", 3, 1);
 ///
 /// // Access "a" multiple times to increase its frequency
 /// assert_eq!(cache.get(&"a"), Some(&1));
 /// assert_eq!(cache.get(&"a"), Some(&1));
 ///
 /// // Add a new item, which will evict the least frequently used item
-/// cache.put("d", 4, None);
+/// cache.put("d", 4, 1);
 /// assert_eq!(cache.get(&"b"), None); // "b" was evicted as it had frequency 0
 /// ```
 #[derive(Debug)]
@@ -847,7 +846,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `value` - The value to cache
-    /// * `size` - Size of this entry for capacity tracking. `None` defaults to `1`.
+    /// * `size` - Size of this entry for capacity tracking. Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Multi-eviction behavior
     ///
@@ -856,7 +855,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     /// free enough space. In this case, only the **last** evicted entry is
     /// returned. For count-based caches, at most one entry is evicted.
     #[inline]
-    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         K: Clone,
     {
@@ -908,8 +907,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfuCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
     ///
     /// // contains() does NOT update frequency
     /// assert!(cache.contains(&"a"));
@@ -940,7 +939,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfuCache::init(config, None);
-    /// cache.put("a", 1, None);
+    /// cache.put("a", 1, 1);
     ///
     /// // peek does not change frequency
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -974,8 +973,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfuCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
     /// cache.get(&"b");  // Increase frequency of "b"
     ///
     /// // Pop the eviction candidate (lowest frequency item)
@@ -1026,7 +1025,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: LfuCache<&str, i32> = LfuCache::init(config, None);
-    /// cache.put("key", 42, None);
+    /// cache.put("key", 42, 1);
     ///
     /// // Cache with size limit
     /// let config = LfuCacheConfig {
@@ -1080,9 +1079,9 @@ mod tests {
         let mut cache = make_cache(3);
 
         // Add items
-        assert_eq!(cache.put("a", 1, None), None);
-        assert_eq!(cache.put("b", 2, None), None);
-        assert_eq!(cache.put("c", 3, None), None);
+        assert_eq!(cache.put("a", 1, 1), None);
+        assert_eq!(cache.put("b", 2, 1), None);
+        assert_eq!(cache.put("c", 3, 1), None);
 
         // Access "a" multiple times to increase its frequency
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1092,7 +1091,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Add a new item, should evict "c" (frequency 0, least recently used among frequency 0)
-        let evicted = cache.put("d", 4, None);
+        let evicted = cache.put("d", 4, 1);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "c");
@@ -1110,8 +1109,8 @@ mod tests {
         let mut cache = make_cache(2);
 
         // Add items
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Access "a" multiple times
         cache.get(&"a");
@@ -1122,7 +1121,7 @@ mod tests {
         cache.get(&"b");
 
         // Add new item, should evict "b" (lower frequency)
-        let evicted = cache.put("c", 3, None);
+        let evicted = cache.put("c", 3, 1);
         assert_eq!(evicted.unwrap().0, "b");
 
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1134,16 +1133,16 @@ mod tests {
     fn test_lfu_update_existing() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
         cache.get(&"a"); // frequency becomes 2
 
         // Update existing key
-        let old_value = cache.put("a", 10, None);
+        let old_value = cache.put("a", 10, 1);
         assert_eq!(old_value.unwrap().1, 1);
 
         // The frequency should be preserved
-        cache.put("b", 2, None);
-        cache.put("c", 3, None); // Should evict "b" because "a" has higher frequency
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1); // Should evict "b" because "a" has higher frequency
 
         assert_eq!(cache.get(&"a"), Some(&10));
         assert_eq!(cache.get(&"c"), Some(&3));
@@ -1154,9 +1153,9 @@ mod tests {
     fn test_lfu_remove() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Remove item
         assert_eq!(cache.remove(&"b"), Some(2));
@@ -1172,9 +1171,9 @@ mod tests {
     fn test_lfu_clear() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         assert_eq!(cache.len(), 3);
         cache.clear();
@@ -1182,7 +1181,7 @@ mod tests {
         assert!(cache.is_empty());
 
         // Should be able to add items after clear
-        cache.put("d", 4, None);
+        cache.put("d", 4, 1);
         assert_eq!(cache.get(&"d"), Some(&4));
     }
 
@@ -1190,7 +1189,7 @@ mod tests {
     fn test_lfu_get_mut() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         // Modify value using get_mut
         if let Some(value) = cache.get_mut(&"a") {
@@ -1217,7 +1216,7 @@ mod tests {
                 id: 1,
                 data: "a-data".to_string(),
             },
-            None,
+            1,
         );
 
         cache.put(
@@ -1226,7 +1225,7 @@ mod tests {
                 id: 2,
                 data: "b-data".to_string(),
             },
-            None,
+            1,
         );
 
         // Modify a value using get_mut
@@ -1247,9 +1246,9 @@ mod tests {
         let mut cache = make_cache(10);
 
         // Insert some items
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access items multiple times to trigger frequency updates
         for _ in 0..3 {
@@ -1281,8 +1280,8 @@ mod tests {
         assert!(segment.is_empty());
         assert_eq!(segment.cap().get(), 3);
 
-        segment.put("a", 1, None);
-        segment.put("b", 2, None);
+        segment.put("a", 1, 1);
+        segment.put("b", 2, 1);
         assert_eq!(segment.len(), 2);
 
         // Access to increase frequency
@@ -1310,7 +1309,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i, None);
+                    guard.put(key.clone(), i, 1);
                     // Access some keys multiple times to test frequency tracking
                     if i % 3 == 0 {
                         let _ = guard.get(&key);
@@ -1336,9 +1335,9 @@ mod tests {
         assert_eq!(cache.current_size(), 0);
         assert_eq!(cache.max_size(), u64::MAX);
 
-        cache.put("a", 1, Some(100));
-        cache.put("b", 2, Some(200));
-        cache.put("c", 3, Some(150));
+        cache.put("a", 1, 100);
+        cache.put("b", 2, 200);
+        cache.put("c", 3, 150);
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1396,7 +1395,7 @@ mod tests {
             } else {
                 format!("long_tail_{}", i) // Many unique keys
             };
-            cache.put(key.clone(), i, None);
+            cache.put(key.clone(), i, 1);
 
             // Also do some gets to build frequency
             if i % 10 == 0 {
@@ -1449,8 +1448,8 @@ mod tests {
     #[test]
     fn test_lfu_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1465,7 +1464,7 @@ mod tests {
         assert!(cache.contains(&"a"));
 
         // Adding "c" should evict "a" (lowest frequency), not "b"
-        cache.put("c", 3, None);
+        cache.put("c", 3, 1);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1474,9 +1473,9 @@ mod tests {
     #[test]
     fn test_lfu_pop_returns_lowest_frequency() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access "b" and "c" to increase their frequencies
         cache.get(&"b");
@@ -1502,9 +1501,9 @@ mod tests {
     #[test]
     fn test_lfu_pop_r_returns_highest_frequency() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access items to build different frequencies
         cache.get(&"b"); // "b" frequency = 2
@@ -1537,7 +1536,7 @@ mod tests {
     #[test]
     fn test_lfu_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1547,7 +1546,7 @@ mod tests {
     #[test]
     fn test_lfu_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1557,15 +1556,15 @@ mod tests {
     #[test]
     fn test_lfu_pop_interleaved_with_put() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Pop lowest frequency
         assert_eq!(cache.pop(), Some(("a", 1)));
 
         // Add new items
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
 
         // "b", "c", "d" all have frequency 1 now. Pop order depends on recency
         assert_eq!(cache.len(), 3);
@@ -1586,11 +1585,11 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert entries: all start with frequency 1
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
-        cache.put("e", 5, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
+        cache.put("e", 5, 1);
 
         // Access some entries to differentiate frequencies
         // a: freq 3, b: freq 2, c: freq 1, d: freq 4, e: freq 1
@@ -1611,7 +1610,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f" with freq 1
-        cache.put("f", 6, None);
+        cache.put("f", 6, 1);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest freq (e with freq 1, older than f)

--- a/src/lfu.rs
+++ b/src/lfu.rs
@@ -616,7 +616,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put()` operations.
+    /// entries to make room during `put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop(&mut self) -> Option<(K, V)> {

--- a/src/lfu.rs
+++ b/src/lfu.rs
@@ -122,16 +122,16 @@
 //! };
 //! let mut cache = LfuCache::init(config, None);
 //!
-//! cache.put("a", 1);
-//! cache.put("b", 2);
-//! cache.put("c", 3);
+//! cache.put("a", 1, None);
+//! cache.put("b", 2, None);
+//! cache.put("c", 3, None);
 //!
 //! // Access "a" multiple times - increases its frequency
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //!
 //! // Add new item - "b" or "c" evicted (both at frequency 1)
-//! cache.put("d", 4);
+//! cache.put("d", 4, None);
 //!
 //! // "a" survives due to higher frequency
 //! assert_eq!(cache.get(&"a"), Some(&1));
@@ -152,7 +152,7 @@
 //! let mut cache: LfuCache<String, Vec<u8>> = LfuCache::init(config, None);
 //!
 //! let data = vec![0u8; 1024];  // 1KB
-//! cache.put_with_size("file.bin".to_string(), data.clone(), 1024);
+//! cache.put("file.bin".to_string(), data.clone(), Some(1024));
 //! ```
 
 extern crate alloc;
@@ -209,7 +209,6 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
-use core::mem;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "hashbrown")]
@@ -319,11 +318,6 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuSegment<K, V, S> {
     #[inline]
     pub(crate) fn max_size(&self) -> u64 {
         self.config.max_size
-    }
-
-    /// Estimates the size of a key-value pair in bytes for metrics tracking
-    fn estimate_object_size(&self, _key: &K, _value: &V) -> u64 {
-        mem::size_of::<K>() as u64 + mem::size_of::<V>() as u64 + 64
     }
 
     /// Returns a reference to the metrics for this segment.
@@ -447,20 +441,15 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuSegment<K, V, S> {
         }
     }
 
-    /// Inserts a key-value pair into the segment.
-    pub(crate) fn put(&mut self, key: K, value: V) -> Option<(K, V)>
+    /// Insert a key-value pair with optional size tracking.
+    ///
+    /// The `size` parameter specifies how much of `max_size` this entry consumes.
+    /// If `None`, defaults to `1` for count-based caching.
+    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         K: Clone,
     {
-        let object_size = self.estimate_object_size(&key, &value);
-        self.put_with_size(key, value, object_size)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
-    pub(crate) fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
-    where
-        K: Clone,
-    {
+        let size = size.unwrap_or(1);
         // If key already exists, update it
         if let Some(&node) = self.map.get(&key) {
             unsafe {
@@ -627,7 +616,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put_with_size()` operations.
+    /// entries to make room during `put()`/`put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop(&mut self) -> Option<(K, V)> {
@@ -757,16 +746,16 @@ impl<K, V, S> core::fmt::Debug for LfuSegment<K, V, S> {
 /// let mut cache = LfuCache::init(config, None);
 ///
 /// // Add some items
-/// cache.put("a", 1);
-/// cache.put("b", 2);
-/// cache.put("c", 3);
+/// cache.put("a", 1, None);
+/// cache.put("b", 2, None);
+/// cache.put("c", 3, None);
 ///
 /// // Access "a" multiple times to increase its frequency
 /// assert_eq!(cache.get(&"a"), Some(&1));
 /// assert_eq!(cache.get(&"a"), Some(&1));
 ///
 /// // Add a new item, which will evict the least frequently used item
-/// cache.put("d", 4);
+/// cache.put("d", 4, None);
 /// assert_eq!(cache.get(&"b"), None); // "b" was evicted as it had frequency 0
 /// ```
 #[derive(Debug)]
@@ -852,31 +841,26 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     /// a large entry may cause **multiple** smaller entries to be evicted to
     /// free enough space. In this case, only the **last** evicted entry is
     /// returned. For count-based caches, at most one entry is evicted.
-    #[inline]
-    pub fn put(&mut self, key: K, value: V) -> Option<(K, V)>
-    where
-        K: Clone,
-    {
-        self.segment.put(key, value)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
+    /// Inserts a key-value pair into the cache.
     ///
-    /// The `size` parameter specifies how much of `max_size` this entry consumes.
-    /// Use `size=1` for count-based caches.
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to cache
+    /// * `size` - Size of this entry for capacity tracking. `None` defaults to `1`.
     ///
     /// # Multi-eviction behavior
     ///
-    /// When the new entry's size would exceed `max_size`, multiple existing
-    /// entries may be evicted to free enough space. Only the **last** evicted
-    /// entry is returned. All evicted entries are counted in the `evictions`
-    /// metric.
+    /// When using size-based caching (`max_size` is not `u64::MAX`), inserting
+    /// a large entry may cause **multiple** smaller entries to be evicted to
+    /// free enough space. In this case, only the **last** evicted entry is
+    /// returned. For count-based caches, at most one entry is evicted.
     #[inline]
-    pub fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         K: Clone,
     {
-        self.segment.put_with_size(key, value, size)
+        self.segment.put(key, value, size)
     }
 
     /// Removes a key from the cache, returning the value at the key if the key was previously in the cache.
@@ -924,8 +908,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfuCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
     ///
     /// // contains() does NOT update frequency
     /// assert!(cache.contains(&"a"));
@@ -956,7 +940,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfuCache::init(config, None);
-    /// cache.put("a", 1);
+    /// cache.put("a", 1, None);
     ///
     /// // peek does not change frequency
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -990,8 +974,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfuCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfuCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
     /// cache.get(&"b");  // Increase frequency of "b"
     ///
     /// // Pop the eviction candidate (lowest frequency item)
@@ -1042,7 +1026,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: LfuCache<&str, i32> = LfuCache::init(config, None);
-    /// cache.put("key", 42);
+    /// cache.put("key", 42, None);
     ///
     /// // Cache with size limit
     /// let config = LfuCacheConfig {
@@ -1096,9 +1080,9 @@ mod tests {
         let mut cache = make_cache(3);
 
         // Add items
-        assert_eq!(cache.put("a", 1), None);
-        assert_eq!(cache.put("b", 2), None);
-        assert_eq!(cache.put("c", 3), None);
+        assert_eq!(cache.put("a", 1, None), None);
+        assert_eq!(cache.put("b", 2, None), None);
+        assert_eq!(cache.put("c", 3, None), None);
 
         // Access "a" multiple times to increase its frequency
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1108,7 +1092,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Add a new item, should evict "c" (frequency 0, least recently used among frequency 0)
-        let evicted = cache.put("d", 4);
+        let evicted = cache.put("d", 4, None);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "c");
@@ -1126,8 +1110,8 @@ mod tests {
         let mut cache = make_cache(2);
 
         // Add items
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Access "a" multiple times
         cache.get(&"a");
@@ -1138,7 +1122,7 @@ mod tests {
         cache.get(&"b");
 
         // Add new item, should evict "b" (lower frequency)
-        let evicted = cache.put("c", 3);
+        let evicted = cache.put("c", 3, None);
         assert_eq!(evicted.unwrap().0, "b");
 
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1150,16 +1134,16 @@ mod tests {
     fn test_lfu_update_existing() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1);
+        cache.put("a", 1, None);
         cache.get(&"a"); // frequency becomes 2
 
         // Update existing key
-        let old_value = cache.put("a", 10);
+        let old_value = cache.put("a", 10, None);
         assert_eq!(old_value.unwrap().1, 1);
 
         // The frequency should be preserved
-        cache.put("b", 2);
-        cache.put("c", 3); // Should evict "b" because "a" has higher frequency
+        cache.put("b", 2, None);
+        cache.put("c", 3, None); // Should evict "b" because "a" has higher frequency
 
         assert_eq!(cache.get(&"a"), Some(&10));
         assert_eq!(cache.get(&"c"), Some(&3));
@@ -1170,9 +1154,9 @@ mod tests {
     fn test_lfu_remove() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Remove item
         assert_eq!(cache.remove(&"b"), Some(2));
@@ -1188,9 +1172,9 @@ mod tests {
     fn test_lfu_clear() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         assert_eq!(cache.len(), 3);
         cache.clear();
@@ -1198,7 +1182,7 @@ mod tests {
         assert!(cache.is_empty());
 
         // Should be able to add items after clear
-        cache.put("d", 4);
+        cache.put("d", 4, None);
         assert_eq!(cache.get(&"d"), Some(&4));
     }
 
@@ -1206,7 +1190,7 @@ mod tests {
     fn test_lfu_get_mut() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         // Modify value using get_mut
         if let Some(value) = cache.get_mut(&"a") {
@@ -1233,6 +1217,7 @@ mod tests {
                 id: 1,
                 data: "a-data".to_string(),
             },
+            None,
         );
 
         cache.put(
@@ -1241,6 +1226,7 @@ mod tests {
                 id: 2,
                 data: "b-data".to_string(),
             },
+            None,
         );
 
         // Modify a value using get_mut
@@ -1261,9 +1247,9 @@ mod tests {
         let mut cache = make_cache(10);
 
         // Insert some items
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access items multiple times to trigger frequency updates
         for _ in 0..3 {
@@ -1295,8 +1281,8 @@ mod tests {
         assert!(segment.is_empty());
         assert_eq!(segment.cap().get(), 3);
 
-        segment.put("a", 1);
-        segment.put("b", 2);
+        segment.put("a", 1, None);
+        segment.put("b", 2, None);
         assert_eq!(segment.len(), 2);
 
         // Access to increase frequency
@@ -1324,7 +1310,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i);
+                    guard.put(key.clone(), i, None);
                     // Access some keys multiple times to test frequency tracking
                     if i % 3 == 0 {
                         let _ = guard.get(&key);
@@ -1350,9 +1336,9 @@ mod tests {
         assert_eq!(cache.current_size(), 0);
         assert_eq!(cache.max_size(), u64::MAX);
 
-        cache.put_with_size("a", 1, 100);
-        cache.put_with_size("b", 2, 200);
-        cache.put_with_size("c", 3, 150);
+        cache.put("a", 1, Some(100));
+        cache.put("b", 2, Some(200));
+        cache.put("c", 3, Some(150));
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1410,7 +1396,7 @@ mod tests {
             } else {
                 format!("long_tail_{}", i) // Many unique keys
             };
-            cache.put(key.clone(), i);
+            cache.put(key.clone(), i, None);
 
             // Also do some gets to build frequency
             if i % 10 == 0 {
@@ -1463,8 +1449,8 @@ mod tests {
     #[test]
     fn test_lfu_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1479,7 +1465,7 @@ mod tests {
         assert!(cache.contains(&"a"));
 
         // Adding "c" should evict "a" (lowest frequency), not "b"
-        cache.put("c", 3);
+        cache.put("c", 3, None);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1488,9 +1474,9 @@ mod tests {
     #[test]
     fn test_lfu_pop_returns_lowest_frequency() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access "b" and "c" to increase their frequencies
         cache.get(&"b");
@@ -1516,9 +1502,9 @@ mod tests {
     #[test]
     fn test_lfu_pop_r_returns_highest_frequency() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access items to build different frequencies
         cache.get(&"b"); // "b" frequency = 2
@@ -1551,7 +1537,7 @@ mod tests {
     #[test]
     fn test_lfu_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1561,7 +1547,7 @@ mod tests {
     #[test]
     fn test_lfu_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1571,15 +1557,15 @@ mod tests {
     #[test]
     fn test_lfu_pop_interleaved_with_put() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Pop lowest frequency
         assert_eq!(cache.pop(), Some(("a", 1)));
 
         // Add new items
-        cache.put("c", 3);
-        cache.put("d", 4);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
 
         // "b", "c", "d" all have frequency 1 now. Pop order depends on recency
         assert_eq!(cache.len(), 3);
@@ -1600,11 +1586,11 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert entries: all start with frequency 1
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
-        cache.put("d", 4);
-        cache.put("e", 5);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
+        cache.put("e", 5, None);
 
         // Access some entries to differentiate frequencies
         // a: freq 3, b: freq 2, c: freq 1, d: freq 4, e: freq 1
@@ -1625,7 +1611,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f" with freq 1
-        cache.put("f", 6);
+        cache.put("f", 6, None);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest freq (e with freq 1, older than f)

--- a/src/lfuda.rs
+++ b/src/lfuda.rs
@@ -150,16 +150,16 @@
 //! };
 //! let mut cache = LfudaCache::init(config, None);
 //!
-//! cache.put("a", 1, None);
-//! cache.put("b", 2, None);
-//! cache.put("c", 3, None);
+//! cache.put("a", 1, 1);
+//! cache.put("b", 2, 1);
+//! cache.put("c", 3, 1);
 //!
 //! // Access "a" to increase its priority
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //!
 //! // Add new item - lowest priority item evicted
-//! cache.put("d", 4, None);
+//! cache.put("d", 4, 1);
 //!
 //! // "a" survives due to higher priority (frequency + age)
 //! assert_eq!(cache.get(&"a"), Some(&1));
@@ -181,7 +181,7 @@
 //!
 //! // Populate cache with initial data
 //! for i in 0..100 {
-//!     cache.put(i, i * 10, None);
+//!     cache.put(i, i * 10, 1);
 //! }
 //!
 //! // Access some items frequently
@@ -191,7 +191,7 @@
 //!
 //! // Later: new content arrives, old content ages out
 //! for i in 100..200 {
-//!     cache.put(i, i * 10, None);  // Each insert may evict old items
+//!     cache.put(i, i * 10, 1);  // Each insert may evict old items
 //! }
 //!
 //! // Item 0 may eventually be evicted if not accessed recently,
@@ -527,12 +527,11 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaSegment<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `value` - The value to insert  
-    /// * `size` - Optional size in bytes. If `None`, defaults to 1.
-    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    /// * `size` - Optional size in bytes. Use `SIZE_UNIT` (1) for count-based caching.
+    pub(crate) fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         K: Clone,
     {
-        let size = size.unwrap_or(1);
         // If key already exists, update it
         if let Some(&node) = self.map.get(&key) {
             unsafe {
@@ -886,17 +885,17 @@ impl<K, V, S> core::fmt::Debug for LfudaSegment<K, V, S> {
 /// let mut cache = LfudaCache::init(config, None);
 ///
 /// // Add some items
-/// cache.put("a", 1, None);
-/// cache.put("b", 2, None);
-/// cache.put("c", 3, None);
+/// cache.put("a", 1, 1);
+/// cache.put("b", 2, 1);
+/// cache.put("c", 3, 1);
 ///
 /// // Access "a" multiple times to increase its frequency
 /// assert_eq!(cache.get(&"a"), Some(&1));
 /// assert_eq!(cache.get(&"a"), Some(&1));
 ///
 /// // Add more items to trigger aging
-/// cache.put("d", 4, None); // This will evict an item and increase global age
-/// cache.put("e", 5, None); // New items benefit from the increased age
+/// cache.put("d", 4, 1); // This will evict an item and increase global age
+/// cache.put("e", 5, 1); // New items benefit from the increased age
 /// ```
 #[derive(Debug)]
 pub struct LfudaCache<K, V, S = DefaultHashBuilder> {
@@ -991,7 +990,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `value` - The value to insert
-    /// * `size` - Optional size in bytes for size-aware caching. If `None`, defaults to 1.
+    /// * `size` - Optional size in bytes for size-aware caching. Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Multi-eviction behavior
     ///
@@ -1000,7 +999,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     /// free enough space. In this case, only the **last** evicted entry is
     /// returned. For count-based caches, at most one entry is evicted.
     #[inline]
-    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         K: Clone,
     {
@@ -1048,8 +1047,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfudaCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
     ///
     /// // contains() does NOT update priority
     /// assert!(cache.contains(&"a"));
@@ -1081,7 +1080,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfudaCache::init(config, None);
-    /// cache.put("a", 1, None);
+    /// cache.put("a", 1, 1);
     ///
     /// // peek does not change priority
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -1116,8 +1115,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfudaCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
     /// cache.get(&"b");  // Increase frequency of "b"
     ///
     /// // Pop the eviction candidate (lowest priority item)
@@ -1179,7 +1178,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: LfudaCache<&str, i32> = LfudaCache::init(config, None);
-    /// cache.put("key", 42, None);
+    /// cache.put("key", 42, 1);
     ///
     /// // Cache with size limit
     /// let config = LfudaCacheConfig {
@@ -1223,9 +1222,9 @@ mod tests {
         let mut cache = make_cache(3);
 
         // Add items
-        assert_eq!(cache.put("a", 1, None), None);
-        assert_eq!(cache.put("b", 2, None), None);
-        assert_eq!(cache.put("c", 3, None), None);
+        assert_eq!(cache.put("a", 1, 1), None);
+        assert_eq!(cache.put("b", 2, 1), None);
+        assert_eq!(cache.put("c", 3, 1), None);
 
         // Access "a" multiple times to increase its frequency
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1235,7 +1234,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Add a new item, should evict "c" (lowest effective priority)
-        let evicted = cache.put("d", 4, None);
+        let evicted = cache.put("d", 4, 1);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "c");
@@ -1253,8 +1252,8 @@ mod tests {
         let mut cache = make_cache(2);
 
         // Add items and access them
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Access "a" many times
         for _ in 0..10 {
@@ -1265,14 +1264,14 @@ mod tests {
         assert_eq!(cache.global_age(), 0);
 
         // Fill cache and cause eviction
-        let evicted = cache.put("c", 3, None);
+        let evicted = cache.put("c", 3, 1);
         assert!(evicted.is_some());
 
         // Global age should have increased after eviction
         assert!(cache.global_age() > 0);
 
         // New items should benefit from the increased global age
-        cache.put("d", 4, None);
+        cache.put("d", 4, 1);
 
         // The new item should start with competitive priority due to aging
         assert!(cache.len() <= cache.cap().get());
@@ -1282,18 +1281,18 @@ mod tests {
     fn test_lfuda_priority_calculation() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
         assert_eq!(cache.global_age(), 0);
 
         // Access "a" to increase its frequency
         cache.get(&"a");
 
         // Add more items
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Force eviction to increase global age
-        let evicted = cache.put("d", 4, None);
+        let evicted = cache.put("d", 4, 1);
         assert!(evicted.is_some());
 
         // Global age should now be greater than 0
@@ -1304,16 +1303,16 @@ mod tests {
     fn test_lfuda_update_existing() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
         cache.get(&"a"); // Increase frequency
 
         // Update existing key
-        let old_value = cache.put("a", 10, None);
+        let old_value = cache.put("a", 10, 1);
         assert_eq!(old_value.unwrap().1, 1);
 
         // Add another item
-        cache.put("b", 2, None);
-        cache.put("c", 3, None); // Should evict "b" because "a" has higher effective priority
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1); // Should evict "b" because "a" has higher effective priority
 
         assert_eq!(cache.get(&"a"), Some(&10));
         assert_eq!(cache.get(&"c"), Some(&3));
@@ -1324,9 +1323,9 @@ mod tests {
     fn test_lfuda_remove() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Remove item
         assert_eq!(cache.remove(&"b"), Some(2));
@@ -1342,13 +1341,13 @@ mod tests {
     fn test_lfuda_clear() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Force some aging
         cache.get(&"a");
-        cache.put("d", 4, None); // This should increase global_age
+        cache.put("d", 4, 1); // This should increase global_age
 
         let age_before_clear = cache.global_age();
         assert!(age_before_clear > 0);
@@ -1359,7 +1358,7 @@ mod tests {
         assert_eq!(cache.global_age(), 0); // Should reset to 0
 
         // Should be able to add items after clear
-        cache.put("e", 5, None);
+        cache.put("e", 5, 1);
         assert_eq!(cache.get(&"e"), Some(&5));
     }
 
@@ -1367,7 +1366,7 @@ mod tests {
     fn test_lfuda_get_mut() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         // Modify value using get_mut
         if let Some(value) = cache.get_mut(&"a") {
@@ -1394,7 +1393,7 @@ mod tests {
                 id: 1,
                 data: "a-data".to_string(),
             },
-            None,
+            1,
         );
 
         cache.put(
@@ -1403,7 +1402,7 @@ mod tests {
                 id: 2,
                 data: "b-data".to_string(),
             },
-            None,
+            1,
         );
 
         // Modify a value using get_mut
@@ -1423,27 +1422,27 @@ mod tests {
         let mut cache = make_cache(2);
 
         // Add and heavily access an old item
-        cache.put("old", 1, None);
+        cache.put("old", 1, 1);
         for _ in 0..100 {
             cache.get(&"old");
         }
 
         // Fill cache
-        cache.put("temp", 2, None);
+        cache.put("temp", 2, 1);
 
         // Force eviction to age the cache
-        let _evicted = cache.put("new1", 3, None);
+        let _evicted = cache.put("new1", 3, 1);
         let age_after_first_eviction = cache.global_age();
 
         // Add more items to further age the cache
-        let _evicted = cache.put("new2", 4, None);
+        let _evicted = cache.put("new2", 4, 1);
         let age_after_second_eviction = cache.global_age();
 
         // The global age should have increased
         assert!(age_after_second_eviction >= age_after_first_eviction);
 
         // Now add a brand new item - it should benefit from the aging
-        cache.put("newer", 5, None);
+        cache.put("newer", 5, 1);
 
         // The newer item should be able to compete despite the old item's high frequency
         assert!(cache.len() <= cache.cap().get());
@@ -1455,9 +1454,9 @@ mod tests {
         let mut cache = make_cache(10);
 
         // Insert some items
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access items multiple times to trigger priority updates
         for _ in 0..3 {
@@ -1491,8 +1490,8 @@ mod tests {
         assert_eq!(segment.cap().get(), 3);
         assert_eq!(segment.global_age(), 0);
 
-        segment.put("a", 1, None);
-        segment.put("b", 2, None);
+        segment.put("a", 1, 1);
+        segment.put("b", 2, 1);
         assert_eq!(segment.len(), 2);
 
         // Access to increase frequency
@@ -1519,7 +1518,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i, None);
+                    guard.put(key.clone(), i, 1);
                     let _ = guard.get(&key);
                 }
             }));
@@ -1541,9 +1540,9 @@ mod tests {
         assert_eq!(cache.current_size(), 0);
         assert_eq!(cache.max_size(), u64::MAX);
 
-        cache.put("a", 1, Some(100));
-        cache.put("b", 2, Some(200));
-        cache.put("c", 3, Some(150));
+        cache.put("a", 1, 100);
+        cache.put("b", 2, 200);
+        cache.put("c", 3, 150);
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1583,8 +1582,8 @@ mod tests {
     #[test]
     fn test_lfuda_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1598,7 +1597,7 @@ mod tests {
         assert!(cache.contains(&"a"));
 
         // Adding "c" should evict "a" (lowest priority), not "b"
-        cache.put("c", 3, None);
+        cache.put("c", 3, 1);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1607,9 +1606,9 @@ mod tests {
     #[test]
     fn test_lfuda_pop_returns_lowest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access "b" and "c" to increase their priorities
         cache.get(&"b");
@@ -1635,9 +1634,9 @@ mod tests {
     #[test]
     fn test_lfuda_pop_r_returns_highest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access items to build different priorities
         cache.get(&"b"); // "b" priority increases
@@ -1670,8 +1669,8 @@ mod tests {
     #[test]
     fn test_lfuda_pop_updates_global_age() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         let initial_age = cache.global_age();
 
@@ -1695,7 +1694,7 @@ mod tests {
     #[test]
     fn test_lfuda_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1705,7 +1704,7 @@ mod tests {
     #[test]
     fn test_lfuda_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1719,9 +1718,9 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert items that will have different priorities
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access "a" to bump its frequency (changes priority)
         cache.get(&"a");
@@ -1736,8 +1735,8 @@ mod tests {
         assert_eq!(cache.get(&"a"), Some(&1));
 
         // Insert new items - should not hit stale empty lists
-        cache.put("d", 4, None);
-        cache.put("e", 5, None);
+        cache.put("d", 4, 1);
+        cache.put("e", 5, 1);
         assert_eq!(cache.len(), 3);
 
         // pop() should work correctly without needing to skip empty lists
@@ -1751,9 +1750,9 @@ mod tests {
         // Verify that removing items at non-minimum priorities also cleans up empty lists.
         let mut cache = make_cache(5);
 
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access "a" many times - it will have a higher priority
         for _ in 0..5 {
@@ -1780,8 +1779,8 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert items at the same initial priority
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Access "a" to move it to a new priority list.
         // If "a" was the only item at that priority, the old list should be removed.
@@ -1795,13 +1794,13 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Insert more items and verify eviction works correctly
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
-        cache.put("e", 5, None);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
+        cache.put("e", 5, 1);
         assert_eq!(cache.len(), 5);
 
         // Force eviction - should work without issues from stale empty lists
-        cache.put("f", 6, None);
+        cache.put("f", 6, 1);
         assert_eq!(cache.len(), 5);
 
         // pop should work correctly
@@ -1815,11 +1814,11 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert entries: all start with frequency 1
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
-        cache.put("e", 5, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
+        cache.put("e", 5, 1);
 
         // Access some entries to differentiate priorities
         // LFUDA priority = frequency + global_age
@@ -1841,7 +1840,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f" with initial freq
-        cache.put("f", 6, None);
+        cache.put("f", 6, 1);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest priority

--- a/src/lfuda.rs
+++ b/src/lfuda.rs
@@ -150,16 +150,16 @@
 //! };
 //! let mut cache = LfudaCache::init(config, None);
 //!
-//! cache.put("a", 1);
-//! cache.put("b", 2);
-//! cache.put("c", 3);
+//! cache.put("a", 1, None);
+//! cache.put("b", 2, None);
+//! cache.put("c", 3, None);
 //!
 //! // Access "a" to increase its priority
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //! assert_eq!(cache.get(&"a"), Some(&1));
 //!
 //! // Add new item - lowest priority item evicted
-//! cache.put("d", 4);
+//! cache.put("d", 4, None);
 //!
 //! // "a" survives due to higher priority (frequency + age)
 //! assert_eq!(cache.get(&"a"), Some(&1));
@@ -181,7 +181,7 @@
 //!
 //! // Populate cache with initial data
 //! for i in 0..100 {
-//!     cache.put(i, i * 10);
+//!     cache.put(i, i * 10, None);
 //! }
 //!
 //! // Access some items frequently
@@ -191,7 +191,7 @@
 //!
 //! // Later: new content arrives, old content ages out
 //! for i in 100..200 {
-//!     cache.put(i, i * 10);  // Each insert may evict old items
+//!     cache.put(i, i * 10, None);  // Each insert may evict old items
 //! }
 //!
 //! // Item 0 may eventually be evicted if not accessed recently,
@@ -268,7 +268,6 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
-use core::mem;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "hashbrown")]
@@ -393,11 +392,6 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaSegment<K, V, S> {
     #[inline]
     pub(crate) fn metrics(&self) -> &LfudaCacheMetrics {
         &self.metrics
-    }
-
-    /// Estimates the size of a key-value pair in bytes for metrics tracking
-    fn estimate_object_size(&self, _key: &K, _value: &V) -> u64 {
-        mem::size_of::<K>() as u64 + mem::size_of::<V>() as u64 + 64
     }
 
     /// Records a cache miss for metrics tracking
@@ -528,19 +522,17 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaSegment<K, V, S> {
     }
 
     /// Inserts a key-value pair into the segment.
-    pub(crate) fn put(&mut self, key: K, value: V) -> Option<(K, V)>
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to insert  
+    /// * `size` - Optional size in bytes. If `None`, defaults to 1.
+    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         K: Clone,
     {
-        let object_size = self.estimate_object_size(&key, &value);
-        self.put_with_size(key, value, object_size)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
-    pub(crate) fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
-    where
-        K: Clone,
-    {
+        let size = size.unwrap_or(1);
         // If key already exists, update it
         if let Some(&node) = self.map.get(&key) {
             unsafe {
@@ -717,7 +709,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put_with_size()` operations.
+    /// entries to make room during `put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop(&mut self) -> Option<(K, V)> {
@@ -894,17 +886,17 @@ impl<K, V, S> core::fmt::Debug for LfudaSegment<K, V, S> {
 /// let mut cache = LfudaCache::init(config, None);
 ///
 /// // Add some items
-/// cache.put("a", 1);
-/// cache.put("b", 2);
-/// cache.put("c", 3);
+/// cache.put("a", 1, None);
+/// cache.put("b", 2, None);
+/// cache.put("c", 3, None);
 ///
 /// // Access "a" multiple times to increase its frequency
 /// assert_eq!(cache.get(&"a"), Some(&1));
 /// assert_eq!(cache.get(&"a"), Some(&1));
 ///
 /// // Add more items to trigger aging
-/// cache.put("d", 4); // This will evict an item and increase global age
-/// cache.put("e", 5); // New items benefit from the increased age
+/// cache.put("d", 4, None); // This will evict an item and increase global age
+/// cache.put("e", 5, None); // New items benefit from the increased age
 /// ```
 #[derive(Debug)]
 pub struct LfudaCache<K, V, S = DefaultHashBuilder> {
@@ -995,6 +987,12 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     /// New items are inserted with a frequency of 1 and age_at_insertion set to the
     /// current global_age.
     ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to insert
+    /// * `size` - Optional size in bytes for size-aware caching. If `None`, defaults to 1.
+    ///
     /// # Multi-eviction behavior
     ///
     /// When using size-based caching (`max_size` is not `u64::MAX`), inserting
@@ -1002,30 +1000,11 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     /// free enough space. In this case, only the **last** evicted entry is
     /// returned. For count-based caches, at most one entry is evicted.
     #[inline]
-    pub fn put(&mut self, key: K, value: V) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         K: Clone,
     {
-        self.segment.put(key, value)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
-    ///
-    /// The `size` parameter specifies how much of `max_size` this entry consumes.
-    /// Use `size=1` for count-based caches.
-    ///
-    /// # Multi-eviction behavior
-    ///
-    /// When the new entry's size would exceed `max_size`, multiple existing
-    /// entries may be evicted to free enough space. Only the **last** evicted
-    /// entry is returned. All evicted entries are counted in the `evictions`
-    /// metric.
-    #[inline]
-    pub fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
-    where
-        K: Clone,
-    {
-        self.segment.put_with_size(key, value, size)
+        self.segment.put(key, value, size)
     }
 
     /// Removes a key from the cache, returning the value at the key if the key was previously in the cache.
@@ -1069,8 +1048,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfudaCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
     ///
     /// // contains() does NOT update priority
     /// assert!(cache.contains(&"a"));
@@ -1102,7 +1081,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfudaCache::init(config, None);
-    /// cache.put("a", 1);
+    /// cache.put("a", 1, None);
     ///
     /// // peek does not change priority
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -1137,8 +1116,8 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LfudaCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LfudaCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
     /// cache.get(&"b");  // Increase frequency of "b"
     ///
     /// // Pop the eviction candidate (lowest priority item)
@@ -1200,7 +1179,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: LfudaCache<&str, i32> = LfudaCache::init(config, None);
-    /// cache.put("key", 42);
+    /// cache.put("key", 42, None);
     ///
     /// // Cache with size limit
     /// let config = LfudaCacheConfig {
@@ -1244,9 +1223,9 @@ mod tests {
         let mut cache = make_cache(3);
 
         // Add items
-        assert_eq!(cache.put("a", 1), None);
-        assert_eq!(cache.put("b", 2), None);
-        assert_eq!(cache.put("c", 3), None);
+        assert_eq!(cache.put("a", 1, None), None);
+        assert_eq!(cache.put("b", 2, None), None);
+        assert_eq!(cache.put("c", 3, None), None);
 
         // Access "a" multiple times to increase its frequency
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1256,7 +1235,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Add a new item, should evict "c" (lowest effective priority)
-        let evicted = cache.put("d", 4);
+        let evicted = cache.put("d", 4, None);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "c");
@@ -1274,8 +1253,8 @@ mod tests {
         let mut cache = make_cache(2);
 
         // Add items and access them
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Access "a" many times
         for _ in 0..10 {
@@ -1286,14 +1265,14 @@ mod tests {
         assert_eq!(cache.global_age(), 0);
 
         // Fill cache and cause eviction
-        let evicted = cache.put("c", 3);
+        let evicted = cache.put("c", 3, None);
         assert!(evicted.is_some());
 
         // Global age should have increased after eviction
         assert!(cache.global_age() > 0);
 
         // New items should benefit from the increased global age
-        cache.put("d", 4);
+        cache.put("d", 4, None);
 
         // The new item should start with competitive priority due to aging
         assert!(cache.len() <= cache.cap().get());
@@ -1303,18 +1282,18 @@ mod tests {
     fn test_lfuda_priority_calculation() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1);
+        cache.put("a", 1, None);
         assert_eq!(cache.global_age(), 0);
 
         // Access "a" to increase its frequency
         cache.get(&"a");
 
         // Add more items
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Force eviction to increase global age
-        let evicted = cache.put("d", 4);
+        let evicted = cache.put("d", 4, None);
         assert!(evicted.is_some());
 
         // Global age should now be greater than 0
@@ -1325,16 +1304,16 @@ mod tests {
     fn test_lfuda_update_existing() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1);
+        cache.put("a", 1, None);
         cache.get(&"a"); // Increase frequency
 
         // Update existing key
-        let old_value = cache.put("a", 10);
+        let old_value = cache.put("a", 10, None);
         assert_eq!(old_value.unwrap().1, 1);
 
         // Add another item
-        cache.put("b", 2);
-        cache.put("c", 3); // Should evict "b" because "a" has higher effective priority
+        cache.put("b", 2, None);
+        cache.put("c", 3, None); // Should evict "b" because "a" has higher effective priority
 
         assert_eq!(cache.get(&"a"), Some(&10));
         assert_eq!(cache.get(&"c"), Some(&3));
@@ -1345,9 +1324,9 @@ mod tests {
     fn test_lfuda_remove() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Remove item
         assert_eq!(cache.remove(&"b"), Some(2));
@@ -1363,13 +1342,13 @@ mod tests {
     fn test_lfuda_clear() {
         let mut cache = make_cache(3);
 
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Force some aging
         cache.get(&"a");
-        cache.put("d", 4); // This should increase global_age
+        cache.put("d", 4, None); // This should increase global_age
 
         let age_before_clear = cache.global_age();
         assert!(age_before_clear > 0);
@@ -1380,7 +1359,7 @@ mod tests {
         assert_eq!(cache.global_age(), 0); // Should reset to 0
 
         // Should be able to add items after clear
-        cache.put("e", 5);
+        cache.put("e", 5, None);
         assert_eq!(cache.get(&"e"), Some(&5));
     }
 
@@ -1388,7 +1367,7 @@ mod tests {
     fn test_lfuda_get_mut() {
         let mut cache = make_cache(2);
 
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         // Modify value using get_mut
         if let Some(value) = cache.get_mut(&"a") {
@@ -1415,6 +1394,7 @@ mod tests {
                 id: 1,
                 data: "a-data".to_string(),
             },
+            None,
         );
 
         cache.put(
@@ -1423,6 +1403,7 @@ mod tests {
                 id: 2,
                 data: "b-data".to_string(),
             },
+            None,
         );
 
         // Modify a value using get_mut
@@ -1442,27 +1423,27 @@ mod tests {
         let mut cache = make_cache(2);
 
         // Add and heavily access an old item
-        cache.put("old", 1);
+        cache.put("old", 1, None);
         for _ in 0..100 {
             cache.get(&"old");
         }
 
         // Fill cache
-        cache.put("temp", 2);
+        cache.put("temp", 2, None);
 
         // Force eviction to age the cache
-        let _evicted = cache.put("new1", 3);
+        let _evicted = cache.put("new1", 3, None);
         let age_after_first_eviction = cache.global_age();
 
         // Add more items to further age the cache
-        let _evicted = cache.put("new2", 4);
+        let _evicted = cache.put("new2", 4, None);
         let age_after_second_eviction = cache.global_age();
 
         // The global age should have increased
         assert!(age_after_second_eviction >= age_after_first_eviction);
 
         // Now add a brand new item - it should benefit from the aging
-        cache.put("newer", 5);
+        cache.put("newer", 5, None);
 
         // The newer item should be able to compete despite the old item's high frequency
         assert!(cache.len() <= cache.cap().get());
@@ -1474,9 +1455,9 @@ mod tests {
         let mut cache = make_cache(10);
 
         // Insert some items
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access items multiple times to trigger priority updates
         for _ in 0..3 {
@@ -1510,8 +1491,8 @@ mod tests {
         assert_eq!(segment.cap().get(), 3);
         assert_eq!(segment.global_age(), 0);
 
-        segment.put("a", 1);
-        segment.put("b", 2);
+        segment.put("a", 1, None);
+        segment.put("b", 2, None);
         assert_eq!(segment.len(), 2);
 
         // Access to increase frequency
@@ -1538,7 +1519,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i);
+                    guard.put(key.clone(), i, None);
                     let _ = guard.get(&key);
                 }
             }));
@@ -1560,9 +1541,9 @@ mod tests {
         assert_eq!(cache.current_size(), 0);
         assert_eq!(cache.max_size(), u64::MAX);
 
-        cache.put_with_size("a", 1, 100);
-        cache.put_with_size("b", 2, 200);
-        cache.put_with_size("c", 3, 150);
+        cache.put("a", 1, Some(100));
+        cache.put("b", 2, Some(200));
+        cache.put("c", 3, Some(150));
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1602,8 +1583,8 @@ mod tests {
     #[test]
     fn test_lfuda_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1617,7 +1598,7 @@ mod tests {
         assert!(cache.contains(&"a"));
 
         // Adding "c" should evict "a" (lowest priority), not "b"
-        cache.put("c", 3);
+        cache.put("c", 3, None);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1626,9 +1607,9 @@ mod tests {
     #[test]
     fn test_lfuda_pop_returns_lowest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access "b" and "c" to increase their priorities
         cache.get(&"b");
@@ -1654,9 +1635,9 @@ mod tests {
     #[test]
     fn test_lfuda_pop_r_returns_highest_priority() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access items to build different priorities
         cache.get(&"b"); // "b" priority increases
@@ -1689,8 +1670,8 @@ mod tests {
     #[test]
     fn test_lfuda_pop_updates_global_age() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         let initial_age = cache.global_age();
 
@@ -1714,7 +1695,7 @@ mod tests {
     #[test]
     fn test_lfuda_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1724,7 +1705,7 @@ mod tests {
     #[test]
     fn test_lfuda_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1738,9 +1719,9 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert items that will have different priorities
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access "a" to bump its frequency (changes priority)
         cache.get(&"a");
@@ -1755,8 +1736,8 @@ mod tests {
         assert_eq!(cache.get(&"a"), Some(&1));
 
         // Insert new items - should not hit stale empty lists
-        cache.put("d", 4);
-        cache.put("e", 5);
+        cache.put("d", 4, None);
+        cache.put("e", 5, None);
         assert_eq!(cache.len(), 3);
 
         // pop() should work correctly without needing to skip empty lists
@@ -1770,9 +1751,9 @@ mod tests {
         // Verify that removing items at non-minimum priorities also cleans up empty lists.
         let mut cache = make_cache(5);
 
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access "a" many times - it will have a higher priority
         for _ in 0..5 {
@@ -1799,8 +1780,8 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert items at the same initial priority
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Access "a" to move it to a new priority list.
         // If "a" was the only item at that priority, the old list should be removed.
@@ -1814,13 +1795,13 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Insert more items and verify eviction works correctly
-        cache.put("c", 3);
-        cache.put("d", 4);
-        cache.put("e", 5);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
+        cache.put("e", 5, None);
         assert_eq!(cache.len(), 5);
 
         // Force eviction - should work without issues from stale empty lists
-        cache.put("f", 6);
+        cache.put("f", 6, None);
         assert_eq!(cache.len(), 5);
 
         // pop should work correctly
@@ -1834,11 +1815,11 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Insert entries: all start with frequency 1
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
-        cache.put("d", 4);
-        cache.put("e", 5);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
+        cache.put("e", 5, None);
 
         // Access some entries to differentiate priorities
         // LFUDA priority = frequency + global_age
@@ -1860,7 +1841,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f" with initial freq
-        cache.put("f", 6);
+        cache.put("f", 6, None);
         assert_eq!(cache.len(), 4);
 
         // pop() removes lowest priority

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,10 @@
 //!     max_size: u64::MAX,
 //! };
 //! let mut cache = LruCache::init(config, None);
-//! cache.put("a", 1, None);
-//! cache.put("b", 2, None);
+//! cache.put("a", 1, 1);
+//! cache.put("b", 2, 1);
 //! cache.get(&"a");      // "a" becomes most recently used
-//! cache.put("c", 3, None);    // "b" evicted (least recently used)
+//! cache.put("c", 3, 1);    // "b" evicted (least recently used)
 //! assert!(cache.get(&"b").is_none());
 //! ```
 //!
@@ -102,7 +102,7 @@
 //! };
 //! let mut cache = SlruCache::init(config, None);
 //!
-//! cache.put("hot", 1, None);
+//! cache.put("hot", 1, 1);
 //! cache.get(&"hot");  // Promoted to protected segment!
 //! ```
 //!
@@ -121,13 +121,13 @@
 //!     max_size: u64::MAX,
 //! };
 //! let mut cache = LfuCache::init(config, None);
-//! cache.put("rare", 1, None);
-//! cache.put("popular", 2, None);
+//! cache.put("rare", 1, 1);
+//! cache.put("popular", 2, 1);
 //!
 //! // Access "popular" multiple times
 //! for _ in 0..10 { cache.get(&"popular"); }
 //!
-//! cache.put("new", 3, None);  // "rare" evicted (lowest frequency)
+//! cache.put("new", 3, 1);  // "rare" evicted (lowest frequency)
 //! assert!(cache.get(&"popular").is_some());
 //! ```
 //!
@@ -150,7 +150,7 @@
 //!
 //! // Old popular items will eventually age out if not accessed
 //! for i in 0..100 {
-//!     cache.put(i, i, None);
+//!     cache.put(i, i, 1);
 //! }
 //! ```
 //!
@@ -172,8 +172,8 @@
 //! let mut cache: GdsfCache<String, Vec<u8>> = GdsfCache::init(config, None);
 //!
 //! // Size-aware insertion
-//! cache.put("small.txt".to_string(), vec![0u8; 100], Some(100));
-//! cache.put("large.bin".to_string(), vec![0u8; 10000], Some(10000));
+//! cache.put("small.txt".to_string(), vec![0u8; 100], 100);
+//! cache.put("large.bin".to_string(), vec![0u8; 10000], 10000);
 //! // Small items get higher priority per byte
 //! ```
 //!
@@ -233,7 +233,7 @@
 //!
 //! // Track size explicitly
 //! let data = vec![0u8; 1024];
-//! cache.put("file.bin".to_string(), data, Some(1024));
+//! cache.put("file.bin".to_string(), data, 1024);
 //! ```
 //!
 //! ## Modules
@@ -328,6 +328,44 @@ pub mod metrics;
 /// Available when the `concurrent` feature is enabled.
 #[cfg(feature = "concurrent")]
 pub mod concurrent;
+
+/// Size value for entry-count mode where actual size doesn't matter.
+///
+/// Use this when you only want to limit the number of entries, not total size.
+/// Each entry will be counted as having size 1, making `current_size()` equal to `len()`.
+///
+/// # Example
+///
+/// ```rust
+/// use cache_rs::{LruCache, SIZE_UNIT};
+/// use cache_rs::config::LruCacheConfig;
+/// use core::num::NonZeroUsize;
+///
+/// let config = LruCacheConfig {
+///     capacity: NonZeroUsize::new(100).unwrap(),
+///     max_size: u64::MAX,  // No size limit
+/// };
+/// let mut cache = LruCache::init(config, None);
+///
+/// // Using SIZE_UNIT for count-based caching
+/// cache.put("key1", "value1", SIZE_UNIT);
+/// cache.put("key2", "value2", SIZE_UNIT);
+/// assert_eq!(cache.len(), 2);
+/// assert_eq!(cache.current_size(), 2);  // Each entry counts as 1
+/// ```
+///
+/// # When to Use
+///
+/// - **Entry-count mode**: When you only care about limiting the number of entries
+/// - **Fixed-size objects**: When all cached items are the same size
+/// - **Simple caching**: When size tracking isn't important for your use case
+///
+/// # When NOT to Use
+///
+/// - **Size-constrained caches**: When `max_size` is set to a real memory limit
+/// - **Variable-sized objects**: When objects have significantly different sizes
+/// - **Size-aware algorithms**: GDSF and LFUDA work better with actual sizes
+pub const SIZE_UNIT: u64 = 1;
 
 // Re-export cache types
 pub use gdsf::GdsfCache;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,10 @@
 //!     max_size: u64::MAX,
 //! };
 //! let mut cache = LruCache::init(config, None);
-//! cache.put("a", 1);
-//! cache.put("b", 2);
+//! cache.put("a", 1, None);
+//! cache.put("b", 2, None);
 //! cache.get(&"a");      // "a" becomes most recently used
-//! cache.put("c", 3);    // "b" evicted (least recently used)
+//! cache.put("c", 3, None);    // "b" evicted (least recently used)
 //! assert!(cache.get(&"b").is_none());
 //! ```
 //!
@@ -102,7 +102,7 @@
 //! };
 //! let mut cache = SlruCache::init(config, None);
 //!
-//! cache.put("hot", 1);
+//! cache.put("hot", 1, None);
 //! cache.get(&"hot");  // Promoted to protected segment!
 //! ```
 //!
@@ -121,13 +121,13 @@
 //!     max_size: u64::MAX,
 //! };
 //! let mut cache = LfuCache::init(config, None);
-//! cache.put("rare", 1);
-//! cache.put("popular", 2);
+//! cache.put("rare", 1, None);
+//! cache.put("popular", 2, None);
 //!
 //! // Access "popular" multiple times
 //! for _ in 0..10 { cache.get(&"popular"); }
 //!
-//! cache.put("new", 3);  // "rare" evicted (lowest frequency)
+//! cache.put("new", 3, None);  // "rare" evicted (lowest frequency)
 //! assert!(cache.get(&"popular").is_some());
 //! ```
 //!
@@ -150,7 +150,7 @@
 //!
 //! // Old popular items will eventually age out if not accessed
 //! for i in 0..100 {
-//!     cache.put(i, i);
+//!     cache.put(i, i, None);
 //! }
 //! ```
 //!
@@ -172,8 +172,8 @@
 //! let mut cache: GdsfCache<String, Vec<u8>> = GdsfCache::init(config, None);
 //!
 //! // Size-aware insertion
-//! cache.put("small.txt".to_string(), vec![0u8; 100], 100);
-//! cache.put("large.bin".to_string(), vec![0u8; 10000], 10000);
+//! cache.put("small.txt".to_string(), vec![0u8; 100], Some(100));
+//! cache.put("large.bin".to_string(), vec![0u8; 10000], Some(10000));
 //! // Small items get higher priority per byte
 //! ```
 //!
@@ -233,7 +233,7 @@
 //!
 //! // Track size explicitly
 //! let data = vec![0u8; 1024];
-//! cache.put_with_size("file.bin".to_string(), data, 1024);
+//! cache.put("file.bin".to_string(), data, Some(1024));
 //! ```
 //!
 //! ## Modules

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -103,13 +103,13 @@
 //! };
 //! let mut cache = LruCache::init(config, None);
 //!
-//! cache.put("a", 1);
-//! cache.put("b", 2);
-//! cache.put("c", 3);
+//! cache.put("a", 1, None);
+//! cache.put("b", 2, None);
+//! cache.put("c", 3, None);
 //!
 //! assert_eq!(cache.get(&"a"), Some(&1));  // "a" is now MRU
 //!
-//! cache.put("d", 4);  // Evicts "b" (LRU)
+//! cache.put("d", 4, None);  // Evicts "b" (LRU)
 //! assert_eq!(cache.get(&"b"), None);
 //! ```
 //!
@@ -128,7 +128,7 @@
 //! let mut cache: LruCache<String, Vec<u8>> = LruCache::init(config, None);
 //!
 //! let data = vec![0u8; 1024];  // 1KB
-//! cache.put_with_size("file.bin".to_string(), data.clone(), 1024);
+//! cache.put("file.bin".to_string(), data.clone(), Some(1024));
 //! ```
 
 extern crate alloc;
@@ -142,7 +142,6 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
-use core::mem;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "hashbrown")]
@@ -243,10 +242,6 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruSegment<K, V, S> {
         &self.metrics
     }
 
-    fn estimate_object_size(&self, _key: &K, _value: &V) -> u64 {
-        mem::size_of::<K>() as u64 + mem::size_of::<V>() as u64 + 64
-    }
-
     pub(crate) fn get<Q>(&mut self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -287,23 +282,15 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruSegment<K, V, S> {
         }
     }
 
-    pub(crate) fn put(&mut self, key: K, value: V) -> Option<(K, V)>
-    where
-        K: Clone + Hash + Eq,
-    {
-        // Use estimated size for backward compatibility
-        let object_size = self.estimate_object_size(&key, &value);
-        self.put_with_size(key, value, object_size)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
+    /// Insert a key-value pair with optional size tracking.
     ///
     /// The `size` parameter specifies how much of `max_size` this entry consumes.
-    /// Use `size=1` for count-based caches.
-    pub(crate) fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
+    /// If `None`, defaults to `1` for count-based caching.
+    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         K: Clone + Hash + Eq,
     {
+        let size = size.unwrap_or(1);
         let mut evicted = None;
 
         if let Some(&node) = self.map.get(&key) {
@@ -419,7 +406,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put_with_size()` operations.
+    /// entries to make room during `put()`/`put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop(&mut self) -> Option<(K, V)> {
@@ -526,12 +513,12 @@ impl<K, V, S> core::fmt::Debug for LruSegment<K, V, S> {
 /// };
 /// let mut cache = LruCache::init(config, None);
 ///
-/// cache.put("apple", 1);
-/// cache.put("banana", 2);
+/// cache.put("apple", 1, None);
+/// cache.put("banana", 2, None);
 /// assert_eq!(cache.get(&"apple"), Some(&1));
 ///
 /// // "banana" is now LRU, so it gets evicted
-/// cache.put("cherry", 3);
+/// cache.put("cherry", 3, None);
 /// assert_eq!(cache.get(&"banana"), None);
 /// ```
 #[derive(Debug)]
@@ -560,7 +547,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruCache<K, V, S> {
 
     /// Returns the current total size of all cached content.
     ///
-    /// This is the sum of all `size` values passed to `put_with_size()`,
+    /// This is the sum of all `size` values passed to `put()`,
     /// or estimated sizes for entries added via `put()`.
     #[inline]
     pub fn current_size(&self) -> u64 {
@@ -592,7 +579,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("key", 42);
+    /// cache.put("key", 42, None);
     ///
     /// assert_eq!(cache.get(&"key"), Some(&42));
     /// assert_eq!(cache.get(&"missing"), None);
@@ -636,7 +623,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("counter", 0);
+    /// cache.put("counter", 0, None);
     ///
     /// if let Some(val) = cache.get_mut(&"counter") {
     ///     *val += 1;
@@ -675,6 +662,12 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     /// returned. For count-based caches (default `max_size = u64::MAX`), at
     /// most one entry is evicted per insertion.
     ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to cache
+    /// * `size` - Size of this entry for capacity tracking. `None` defaults to `1`.
+    ///
     /// # Example
     ///
     /// ```
@@ -688,39 +681,14 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     /// };
     /// let mut cache = LruCache::init(config, None);
     ///
-    /// assert_eq!(cache.put("a", 1), None);           // New entry
-    /// assert_eq!(cache.put("b", 2), None);           // New entry
-    /// assert_eq!(cache.put("a", 10), Some(("a", 1))); // Update existing
-    /// assert_eq!(cache.put("c", 3), Some(("b", 2))); // Evicts "b"
+    /// // Count-based caching (size defaults to 1)
+    /// assert_eq!(cache.put("a", 1, None), None);           // New entry
+    /// assert_eq!(cache.put("b", 2, None), None);           // New entry
+    /// assert_eq!(cache.put("a", 10, None), Some(("a", 1))); // Update existing
+    /// assert_eq!(cache.put("c", 3, None), Some(("b", 2)));  // Evicts "b"
     /// ```
-    #[inline]
-    pub fn put(&mut self, key: K, value: V) -> Option<(K, V)> {
-        self.segment.put(key, value)
-    }
-
-    /// Inserts a key-value pair with an explicit size.
     ///
-    /// Use this for size-aware caching where you want to track the actual
-    /// memory or storage footprint of cached items.
-    ///
-    /// # Multi-eviction behavior
-    ///
-    /// When the new entry's size would exceed `max_size`, multiple existing
-    /// entries may be evicted to free enough space. Only the **last** evicted
-    /// entry is returned. All evicted entries are counted in the `evictions`
-    /// metric.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The key to insert
-    /// * `value` - The value to cache
-    /// * `size` - The size this entry consumes (in your chosen unit, e.g., bytes)
-    ///
-    /// # Returns
-    ///
-    /// Same as `put()` - returns evicted or replaced entry if any.
-    ///
-    /// # Example
+    /// Size-aware caching:
     ///
     /// ```
     /// use cache_rs::LruCache;
@@ -734,13 +702,13 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     /// let mut cache: LruCache<String, Vec<u8>> = LruCache::init(config, None);
     ///
     /// let data = vec![0u8; 1000];
-    /// cache.put_with_size("file".to_string(), data, 1000);
+    /// cache.put("file".to_string(), data, Some(1000));
     ///
     /// assert_eq!(cache.current_size(), 1000);
     /// ```
     #[inline]
-    pub fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)> {
-        self.segment.put_with_size(key, value, size)
+    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+        self.segment.put(key, value, size)
     }
 
     /// Removes a key from the cache.
@@ -759,7 +727,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("key", 42);
+    /// cache.put("key", 42, None);
     ///
     /// assert_eq!(cache.remove(&"key"), Some(42));
     /// assert_eq!(cache.remove(&"key"), None);  // Already removed
@@ -799,14 +767,14 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
     ///
     /// // contains() does NOT promote "a"
     /// assert!(cache.contains(&"a"));
     ///
     /// // "a" is still LRU, so adding "c" evicts "a"
-    /// cache.put("c", 3);
+    /// cache.put("c", 3, None);
     /// assert!(!cache.contains(&"a"));
     /// ```
     #[inline]
@@ -835,8 +803,8 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
     ///
     /// // peek does not change LRU ordering
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -870,9 +838,9 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
-    /// cache.put("c", 3);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
+    /// cache.put("c", 3, None);
     ///
     /// // Pop the eviction candidate (LRU item)
     /// assert_eq!(cache.pop(), Some(("a", 1)));
@@ -941,7 +909,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: LruCache<&str, i32> = LruCache::init(config, None);
-    /// cache.put("key", 42);
+    /// cache.put("key", 42, None);
     ///
     /// // Cache with size limit
     /// let config = LruCacheConfig {
@@ -996,14 +964,14 @@ mod tests {
     #[test]
     fn test_lru_get_put() {
         let mut cache = make_cache(2);
-        assert_eq!(cache.put("apple", 1), None);
-        assert_eq!(cache.put("banana", 2), None);
+        assert_eq!(cache.put("apple", 1, None), None);
+        assert_eq!(cache.put("banana", 2, None), None);
         assert_eq!(cache.get(&"apple"), Some(&1));
         assert_eq!(cache.get(&"banana"), Some(&2));
         assert_eq!(cache.get(&"cherry"), None);
-        assert_eq!(cache.put("apple", 3).unwrap().1, 1);
+        assert_eq!(cache.put("apple", 3, None).unwrap().1, 1);
         assert_eq!(cache.get(&"apple"), Some(&3));
-        assert_eq!(cache.put("cherry", 4).unwrap().1, 2);
+        assert_eq!(cache.put("cherry", 4, None).unwrap().1, 2);
         assert_eq!(cache.get(&"banana"), None);
         assert_eq!(cache.get(&"apple"), Some(&3));
         assert_eq!(cache.get(&"cherry"), Some(&4));
@@ -1012,13 +980,13 @@ mod tests {
     #[test]
     fn test_lru_get_mut() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1);
-        cache.put("banana", 2);
+        cache.put("apple", 1, None);
+        cache.put("banana", 2, None);
         if let Some(v) = cache.get_mut(&"apple") {
             *v = 3;
         }
         assert_eq!(cache.get(&"apple"), Some(&3));
-        cache.put("cherry", 4);
+        cache.put("cherry", 4, None);
         assert_eq!(cache.get(&"banana"), None);
         assert_eq!(cache.get(&"apple"), Some(&3));
         assert_eq!(cache.get(&"cherry"), Some(&4));
@@ -1027,8 +995,8 @@ mod tests {
     #[test]
     fn test_lru_remove() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1);
-        cache.put("banana", 2);
+        cache.put("apple", 1, None);
+        cache.put("banana", 2, None);
         assert_eq!(cache.get(&"apple"), Some(&1));
         assert_eq!(cache.get(&"banana"), Some(&2));
         assert_eq!(cache.get(&"cherry"), None);
@@ -1036,7 +1004,7 @@ mod tests {
         assert_eq!(cache.get(&"apple"), None);
         assert_eq!(cache.len(), 1);
         assert_eq!(cache.remove(&"cherry"), None);
-        let evicted = cache.put("cherry", 3);
+        let evicted = cache.put("cherry", 3, None);
         assert_eq!(evicted, None);
         assert_eq!(cache.get(&"banana"), Some(&2));
         assert_eq!(cache.get(&"cherry"), Some(&3));
@@ -1045,22 +1013,22 @@ mod tests {
     #[test]
     fn test_lru_clear() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1);
-        cache.put("banana", 2);
+        cache.put("apple", 1, None);
+        cache.put("banana", 2, None);
         assert_eq!(cache.len(), 2);
         cache.clear();
         assert_eq!(cache.len(), 0);
         assert!(cache.is_empty());
-        cache.put("cherry", 3);
+        cache.put("cherry", 3, None);
         assert_eq!(cache.get(&"cherry"), Some(&3));
     }
 
     #[test]
     fn test_lru_capacity_limits() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1);
-        cache.put("banana", 2);
-        cache.put("cherry", 3);
+        cache.put("apple", 1, None);
+        cache.put("banana", 2, None);
+        cache.put("cherry", 3, None);
         assert_eq!(cache.len(), 2);
         assert_eq!(cache.get(&"apple"), None);
         assert_eq!(cache.get(&"banana"), Some(&2));
@@ -1072,8 +1040,8 @@ mod tests {
         let mut cache = make_cache(2);
         let key1 = String::from("apple");
         let key2 = String::from("banana");
-        cache.put(key1.clone(), 1);
-        cache.put(key2.clone(), 2);
+        cache.put(key1.clone(), 1, None);
+        cache.put(key2.clone(), 2, None);
         assert_eq!(cache.get(&key1), Some(&1));
         assert_eq!(cache.get(&key2), Some(&2));
         assert_eq!(cache.get("apple"), Some(&1));
@@ -1104,11 +1072,11 @@ mod tests {
             val: 3,
             description: String::from("Third fruit"),
         };
-        cache.put(key1.clone(), fruit1.clone());
-        cache.put(key2.clone(), fruit2.clone());
+        cache.put(key1.clone(), fruit1.clone(), None);
+        cache.put(key2.clone(), fruit2.clone(), None);
         assert_eq!(cache.get(&key1).unwrap().val, fruit1.val);
         assert_eq!(cache.get(&key2).unwrap().val, fruit2.val);
-        let evicted = cache.put(String::from("cherry"), fruit3.clone());
+        let evicted = cache.put(String::from("cherry"), fruit3.clone(), None);
         let evicted_fruit = evicted.unwrap();
         assert_eq!(evicted_fruit.1, fruit1);
         let removed = cache.remove(&key1);
@@ -1123,8 +1091,8 @@ mod tests {
         assert_eq!(metrics.get("requests").unwrap(), &0.0);
         assert_eq!(metrics.get("cache_hits").unwrap(), &0.0);
         assert_eq!(metrics.get("cache_misses").unwrap(), &0.0);
-        cache.put("apple", 1);
-        cache.put("banana", 2);
+        cache.put("apple", 1, None);
+        cache.put("banana", 2, None);
         cache.get(&"apple");
         cache.get(&"banana");
         let metrics = cache.metrics();
@@ -1133,7 +1101,7 @@ mod tests {
         let metrics = cache.metrics();
         assert_eq!(metrics.get("cache_misses").unwrap(), &1.0);
         assert_eq!(metrics.get("requests").unwrap(), &3.0);
-        cache.put("cherry", 3);
+        cache.put("cherry", 3, None);
         let metrics = cache.metrics();
         assert_eq!(metrics.get("evictions").unwrap(), &1.0);
         assert!(metrics.get("bytes_written_to_cache").unwrap() > &0.0);
@@ -1151,8 +1119,8 @@ mod tests {
         assert_eq!(segment.len(), 0);
         assert!(segment.is_empty());
         assert_eq!(segment.cap().get(), 2);
-        segment.put("a", 1);
-        segment.put("b", 2);
+        segment.put("a", 1, None);
+        segment.put("b", 2, None);
         assert_eq!(segment.len(), 2);
         assert_eq!(segment.get(&"a"), Some(&1));
         assert_eq!(segment.get(&"b"), Some(&2));
@@ -1178,7 +1146,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("thread_{}_key_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key, t * 1000 + i);
+                    guard.put(key, t * 1000 + i, None);
                 }
             }));
         }
@@ -1225,7 +1193,7 @@ mod tests {
                     let key = std::format!("key_{}", i % 100); // Overlapping keys
                     let mut guard = cache.lock().unwrap();
                     if i % 2 == 0 {
-                        guard.put(key, t * 1000 + i);
+                        guard.put(key, t * 1000 + i, None);
                     } else {
                         let _ = guard.get(&key);
                     }
@@ -1264,7 +1232,7 @@ mod tests {
 
                     match i % 4 {
                         0 => {
-                            guard.put(key, i);
+                            guard.put(key, i, None);
                         }
                         1 => {
                             let _ = guard.get(&key);
@@ -1303,9 +1271,9 @@ mod tests {
         assert_eq!(cache.max_size(), u64::MAX);
 
         // Put items with explicit sizes
-        cache.put_with_size("a", 1, 100);
-        cache.put_with_size("b", 2, 200);
-        cache.put_with_size("c", 3, 150);
+        cache.put("a", 1, Some(100));
+        cache.put("b", 2, Some(200));
+        cache.put("c", 3, Some(150));
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1349,8 +1317,8 @@ mod tests {
     #[test]
     fn test_lru_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1359,7 +1327,7 @@ mod tests {
 
         // contains() should NOT promote "a", so it's still LRU
         // Adding "c" should evict "a", not "b"
-        cache.put("c", 3);
+        cache.put("c", 3, None);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1368,9 +1336,9 @@ mod tests {
     #[test]
     fn test_lru_pop_returns_lru() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // pop() should return the LRU (oldest) item
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1391,9 +1359,9 @@ mod tests {
     #[test]
     fn test_lru_pop_r_returns_mru() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // pop_r() should return the MRU (newest) item
         assert_eq!(cache.pop_r(), Some(("c", 3)));
@@ -1414,9 +1382,9 @@ mod tests {
     #[test]
     fn test_lru_pop_after_access() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Access "a" to make it MRU
         cache.get(&"a");
@@ -1436,7 +1404,7 @@ mod tests {
     #[test]
     fn test_lru_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         // Both pop() and pop_r() should return the same element
         let popped = cache.pop();
@@ -1447,7 +1415,7 @@ mod tests {
     #[test]
     fn test_lru_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1457,15 +1425,15 @@ mod tests {
     #[test]
     fn test_lru_pop_interleaved_with_put() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Pop LRU
         assert_eq!(cache.pop(), Some(("a", 1)));
 
         // Add new items
-        cache.put("c", 3);
-        cache.put("d", 4);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
 
         // Order is now: b (LRU) -> c -> d (MRU)
         assert_eq!(cache.pop(), Some(("b", 2)));
@@ -1477,9 +1445,9 @@ mod tests {
     #[test]
     fn test_pop_does_not_inflate_eviction_count() {
         let mut cache = make_cache(3);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Manual pop should NOT count as eviction
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1494,16 +1462,16 @@ mod tests {
     #[test]
     fn test_put_eviction_increments_eviction_count() {
         let mut cache = make_cache(2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
         assert_eq!(cache.segment.metrics().core.evictions, 0);
 
         // Inserting a 3rd item should evict one (capacity=2)
-        cache.put("c", 3);
+        cache.put("c", 3, None);
         assert_eq!(cache.segment.metrics().core.evictions, 1);
 
         // Another insert should evict again
-        cache.put("d", 4);
+        cache.put("d", 4, None);
         assert_eq!(cache.segment.metrics().core.evictions, 2);
     }
 
@@ -1512,11 +1480,11 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Initial state: a(LRU) -> b -> c -> d -> e(MRU)
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
-        cache.put("d", 4);
-        cache.put("e", 5);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
+        cache.put("e", 5, None);
 
         // pop LRU: removes "a", order: b(LRU) -> c -> d -> e(MRU)
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1530,7 +1498,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f": c(LRU) -> d -> e -> f(MRU)
-        cache.put("f", 6);
+        cache.put("f", 6, None);
         assert_eq!(cache.len(), 4);
 
         // pop LRU: removes "c", order: d(LRU) -> e -> f(MRU)

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -406,7 +406,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruSegment<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put()` operations.
+    /// entries to make room during `put()` operations.
     ///
     /// Returns `None` if the cache is empty.
     pub(crate) fn pop(&mut self) -> Option<(K, V)> {

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -103,13 +103,13 @@
 //! };
 //! let mut cache = LruCache::init(config, None);
 //!
-//! cache.put("a", 1, None);
-//! cache.put("b", 2, None);
-//! cache.put("c", 3, None);
+//! cache.put("a", 1, 1);
+//! cache.put("b", 2, 1);
+//! cache.put("c", 3, 1);
 //!
 //! assert_eq!(cache.get(&"a"), Some(&1));  // "a" is now MRU
 //!
-//! cache.put("d", 4, None);  // Evicts "b" (LRU)
+//! cache.put("d", 4, 1);  // Evicts "b" (LRU)
 //! assert_eq!(cache.get(&"b"), None);
 //! ```
 //!
@@ -128,7 +128,7 @@
 //! let mut cache: LruCache<String, Vec<u8>> = LruCache::init(config, None);
 //!
 //! let data = vec![0u8; 1024];  // 1KB
-//! cache.put("file.bin".to_string(), data.clone(), Some(1024));
+//! cache.put("file.bin".to_string(), data.clone(), 1024);
 //! ```
 
 extern crate alloc;
@@ -282,15 +282,14 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruSegment<K, V, S> {
         }
     }
 
-    /// Insert a key-value pair with optional size tracking.
+    /// Insert a key-value pair with size tracking.
     ///
     /// The `size` parameter specifies how much of `max_size` this entry consumes.
-    /// If `None`, defaults to `1` for count-based caching.
-    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    /// Use `SIZE_UNIT` (1) for count-based caching.
+    pub(crate) fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         K: Clone + Hash + Eq,
     {
-        let size = size.unwrap_or(1);
         let mut evicted = None;
 
         if let Some(&node) = self.map.get(&key) {
@@ -513,12 +512,12 @@ impl<K, V, S> core::fmt::Debug for LruSegment<K, V, S> {
 /// };
 /// let mut cache = LruCache::init(config, None);
 ///
-/// cache.put("apple", 1, None);
-/// cache.put("banana", 2, None);
+/// cache.put("apple", 1, 1);
+/// cache.put("banana", 2, 1);
 /// assert_eq!(cache.get(&"apple"), Some(&1));
 ///
 /// // "banana" is now LRU, so it gets evicted
-/// cache.put("cherry", 3, None);
+/// cache.put("cherry", 3, 1);
 /// assert_eq!(cache.get(&"banana"), None);
 /// ```
 #[derive(Debug)]
@@ -579,7 +578,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("key", 42, None);
+    /// cache.put("key", 42, 1);
     ///
     /// assert_eq!(cache.get(&"key"), Some(&42));
     /// assert_eq!(cache.get(&"missing"), None);
@@ -623,7 +622,7 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("counter", 0, None);
+    /// cache.put("counter", 0, 1);
     ///
     /// if let Some(val) = cache.get_mut(&"counter") {
     ///     *val += 1;
@@ -666,7 +665,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `value` - The value to cache
-    /// * `size` - Size of this entry for capacity tracking. `None` defaults to `1`.
+    /// * `size` - Size of this entry for capacity tracking. Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Example
     ///
@@ -681,11 +680,11 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     /// };
     /// let mut cache = LruCache::init(config, None);
     ///
-    /// // Count-based caching (size defaults to 1)
-    /// assert_eq!(cache.put("a", 1, None), None);           // New entry
-    /// assert_eq!(cache.put("b", 2, None), None);           // New entry
-    /// assert_eq!(cache.put("a", 10, None), Some(("a", 1))); // Update existing
-    /// assert_eq!(cache.put("c", 3, None), Some(("b", 2)));  // Evicts "b"
+    /// // Count-based caching (use 1 for size)
+    /// assert_eq!(cache.put("a", 1, 1), None);           // New entry
+    /// assert_eq!(cache.put("b", 2, 1), None);           // New entry
+    /// assert_eq!(cache.put("a", 10, 1), Some(("a", 1))); // Update existing
+    /// assert_eq!(cache.put("c", 3, 1), Some(("b", 2)));  // Evicts "b"
     /// ```
     ///
     /// Size-aware caching:
@@ -702,12 +701,12 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     /// let mut cache: LruCache<String, Vec<u8>> = LruCache::init(config, None);
     ///
     /// let data = vec![0u8; 1000];
-    /// cache.put("file".to_string(), data, Some(1000));
+    /// cache.put("file".to_string(), data, 1000);
     ///
     /// assert_eq!(cache.current_size(), 1000);
     /// ```
     #[inline]
-    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)> {
+    pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)> {
         self.segment.put(key, value, size)
     }
 
@@ -727,7 +726,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("key", 42, None);
+    /// cache.put("key", 42, 1);
     ///
     /// assert_eq!(cache.remove(&"key"), Some(42));
     /// assert_eq!(cache.remove(&"key"), None);  // Already removed
@@ -767,14 +766,14 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
     ///
     /// // contains() does NOT promote "a"
     /// assert!(cache.contains(&"a"));
     ///
     /// // "a" is still LRU, so adding "c" evicts "a"
-    /// cache.put("c", 3, None);
+    /// cache.put("c", 3, 1);
     /// assert!(!cache.contains(&"a"));
     /// ```
     #[inline]
@@ -803,8 +802,8 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
     ///
     /// // peek does not change LRU ordering
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -838,9 +837,9 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher> LruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = LruCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
-    /// cache.put("c", 3, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
+    /// cache.put("c", 3, 1);
     ///
     /// // Pop the eviction candidate (LRU item)
     /// assert_eq!(cache.pop(), Some(("a", 1)));
@@ -909,7 +908,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: LruCache<&str, i32> = LruCache::init(config, None);
-    /// cache.put("key", 42, None);
+    /// cache.put("key", 42, 1);
     ///
     /// // Cache with size limit
     /// let config = LruCacheConfig {
@@ -964,14 +963,14 @@ mod tests {
     #[test]
     fn test_lru_get_put() {
         let mut cache = make_cache(2);
-        assert_eq!(cache.put("apple", 1, None), None);
-        assert_eq!(cache.put("banana", 2, None), None);
+        assert_eq!(cache.put("apple", 1, 1), None);
+        assert_eq!(cache.put("banana", 2, 1), None);
         assert_eq!(cache.get(&"apple"), Some(&1));
         assert_eq!(cache.get(&"banana"), Some(&2));
         assert_eq!(cache.get(&"cherry"), None);
-        assert_eq!(cache.put("apple", 3, None).unwrap().1, 1);
+        assert_eq!(cache.put("apple", 3, 1).unwrap().1, 1);
         assert_eq!(cache.get(&"apple"), Some(&3));
-        assert_eq!(cache.put("cherry", 4, None).unwrap().1, 2);
+        assert_eq!(cache.put("cherry", 4, 1).unwrap().1, 2);
         assert_eq!(cache.get(&"banana"), None);
         assert_eq!(cache.get(&"apple"), Some(&3));
         assert_eq!(cache.get(&"cherry"), Some(&4));
@@ -980,13 +979,13 @@ mod tests {
     #[test]
     fn test_lru_get_mut() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1, None);
-        cache.put("banana", 2, None);
+        cache.put("apple", 1, 1);
+        cache.put("banana", 2, 1);
         if let Some(v) = cache.get_mut(&"apple") {
             *v = 3;
         }
         assert_eq!(cache.get(&"apple"), Some(&3));
-        cache.put("cherry", 4, None);
+        cache.put("cherry", 4, 1);
         assert_eq!(cache.get(&"banana"), None);
         assert_eq!(cache.get(&"apple"), Some(&3));
         assert_eq!(cache.get(&"cherry"), Some(&4));
@@ -995,8 +994,8 @@ mod tests {
     #[test]
     fn test_lru_remove() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1, None);
-        cache.put("banana", 2, None);
+        cache.put("apple", 1, 1);
+        cache.put("banana", 2, 1);
         assert_eq!(cache.get(&"apple"), Some(&1));
         assert_eq!(cache.get(&"banana"), Some(&2));
         assert_eq!(cache.get(&"cherry"), None);
@@ -1004,7 +1003,7 @@ mod tests {
         assert_eq!(cache.get(&"apple"), None);
         assert_eq!(cache.len(), 1);
         assert_eq!(cache.remove(&"cherry"), None);
-        let evicted = cache.put("cherry", 3, None);
+        let evicted = cache.put("cherry", 3, 1);
         assert_eq!(evicted, None);
         assert_eq!(cache.get(&"banana"), Some(&2));
         assert_eq!(cache.get(&"cherry"), Some(&3));
@@ -1013,22 +1012,22 @@ mod tests {
     #[test]
     fn test_lru_clear() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1, None);
-        cache.put("banana", 2, None);
+        cache.put("apple", 1, 1);
+        cache.put("banana", 2, 1);
         assert_eq!(cache.len(), 2);
         cache.clear();
         assert_eq!(cache.len(), 0);
         assert!(cache.is_empty());
-        cache.put("cherry", 3, None);
+        cache.put("cherry", 3, 1);
         assert_eq!(cache.get(&"cherry"), Some(&3));
     }
 
     #[test]
     fn test_lru_capacity_limits() {
         let mut cache = make_cache(2);
-        cache.put("apple", 1, None);
-        cache.put("banana", 2, None);
-        cache.put("cherry", 3, None);
+        cache.put("apple", 1, 1);
+        cache.put("banana", 2, 1);
+        cache.put("cherry", 3, 1);
         assert_eq!(cache.len(), 2);
         assert_eq!(cache.get(&"apple"), None);
         assert_eq!(cache.get(&"banana"), Some(&2));
@@ -1040,8 +1039,8 @@ mod tests {
         let mut cache = make_cache(2);
         let key1 = String::from("apple");
         let key2 = String::from("banana");
-        cache.put(key1.clone(), 1, None);
-        cache.put(key2.clone(), 2, None);
+        cache.put(key1.clone(), 1, 1);
+        cache.put(key2.clone(), 2, 1);
         assert_eq!(cache.get(&key1), Some(&1));
         assert_eq!(cache.get(&key2), Some(&2));
         assert_eq!(cache.get("apple"), Some(&1));
@@ -1072,11 +1071,11 @@ mod tests {
             val: 3,
             description: String::from("Third fruit"),
         };
-        cache.put(key1.clone(), fruit1.clone(), None);
-        cache.put(key2.clone(), fruit2.clone(), None);
+        cache.put(key1.clone(), fruit1.clone(), 1);
+        cache.put(key2.clone(), fruit2.clone(), 1);
         assert_eq!(cache.get(&key1).unwrap().val, fruit1.val);
         assert_eq!(cache.get(&key2).unwrap().val, fruit2.val);
-        let evicted = cache.put(String::from("cherry"), fruit3.clone(), None);
+        let evicted = cache.put(String::from("cherry"), fruit3.clone(), 1);
         let evicted_fruit = evicted.unwrap();
         assert_eq!(evicted_fruit.1, fruit1);
         let removed = cache.remove(&key1);
@@ -1091,8 +1090,8 @@ mod tests {
         assert_eq!(metrics.get("requests").unwrap(), &0.0);
         assert_eq!(metrics.get("cache_hits").unwrap(), &0.0);
         assert_eq!(metrics.get("cache_misses").unwrap(), &0.0);
-        cache.put("apple", 1, None);
-        cache.put("banana", 2, None);
+        cache.put("apple", 1, 1);
+        cache.put("banana", 2, 1);
         cache.get(&"apple");
         cache.get(&"banana");
         let metrics = cache.metrics();
@@ -1101,7 +1100,7 @@ mod tests {
         let metrics = cache.metrics();
         assert_eq!(metrics.get("cache_misses").unwrap(), &1.0);
         assert_eq!(metrics.get("requests").unwrap(), &3.0);
-        cache.put("cherry", 3, None);
+        cache.put("cherry", 3, 1);
         let metrics = cache.metrics();
         assert_eq!(metrics.get("evictions").unwrap(), &1.0);
         assert!(metrics.get("bytes_written_to_cache").unwrap() > &0.0);
@@ -1119,8 +1118,8 @@ mod tests {
         assert_eq!(segment.len(), 0);
         assert!(segment.is_empty());
         assert_eq!(segment.cap().get(), 2);
-        segment.put("a", 1, None);
-        segment.put("b", 2, None);
+        segment.put("a", 1, 1);
+        segment.put("b", 2, 1);
         assert_eq!(segment.len(), 2);
         assert_eq!(segment.get(&"a"), Some(&1));
         assert_eq!(segment.get(&"b"), Some(&2));
@@ -1146,7 +1145,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("thread_{}_key_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key, t * 1000 + i, None);
+                    guard.put(key, t * 1000 + i, 1);
                 }
             }));
         }
@@ -1193,7 +1192,7 @@ mod tests {
                     let key = std::format!("key_{}", i % 100); // Overlapping keys
                     let mut guard = cache.lock().unwrap();
                     if i % 2 == 0 {
-                        guard.put(key, t * 1000 + i, None);
+                        guard.put(key, t * 1000 + i, 1);
                     } else {
                         let _ = guard.get(&key);
                     }
@@ -1232,7 +1231,7 @@ mod tests {
 
                     match i % 4 {
                         0 => {
-                            guard.put(key, i, None);
+                            guard.put(key, i, 1);
                         }
                         1 => {
                             let _ = guard.get(&key);
@@ -1271,9 +1270,9 @@ mod tests {
         assert_eq!(cache.max_size(), u64::MAX);
 
         // Put items with explicit sizes
-        cache.put("a", 1, Some(100));
-        cache.put("b", 2, Some(200));
-        cache.put("c", 3, Some(150));
+        cache.put("a", 1, 100);
+        cache.put("b", 2, 200);
+        cache.put("c", 3, 150);
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1317,8 +1316,8 @@ mod tests {
     #[test]
     fn test_lru_contains_non_promoting() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1327,7 +1326,7 @@ mod tests {
 
         // contains() should NOT promote "a", so it's still LRU
         // Adding "c" should evict "a", not "b"
-        cache.put("c", 3, None);
+        cache.put("c", 3, 1);
         assert!(!cache.contains(&"a")); // "a" was evicted
         assert!(cache.contains(&"b")); // "b" still exists
         assert!(cache.contains(&"c")); // "c" was just added
@@ -1336,9 +1335,9 @@ mod tests {
     #[test]
     fn test_lru_pop_returns_lru() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // pop() should return the LRU (oldest) item
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1359,9 +1358,9 @@ mod tests {
     #[test]
     fn test_lru_pop_r_returns_mru() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // pop_r() should return the MRU (newest) item
         assert_eq!(cache.pop_r(), Some(("c", 3)));
@@ -1382,9 +1381,9 @@ mod tests {
     #[test]
     fn test_lru_pop_after_access() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Access "a" to make it MRU
         cache.get(&"a");
@@ -1404,7 +1403,7 @@ mod tests {
     #[test]
     fn test_lru_pop_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         // Both pop() and pop_r() should return the same element
         let popped = cache.pop();
@@ -1415,7 +1414,7 @@ mod tests {
     #[test]
     fn test_lru_pop_r_single_element() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1425,15 +1424,15 @@ mod tests {
     #[test]
     fn test_lru_pop_interleaved_with_put() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Pop LRU
         assert_eq!(cache.pop(), Some(("a", 1)));
 
         // Add new items
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
 
         // Order is now: b (LRU) -> c -> d (MRU)
         assert_eq!(cache.pop(), Some(("b", 2)));
@@ -1445,9 +1444,9 @@ mod tests {
     #[test]
     fn test_pop_does_not_inflate_eviction_count() {
         let mut cache = make_cache(3);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Manual pop should NOT count as eviction
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1462,16 +1461,16 @@ mod tests {
     #[test]
     fn test_put_eviction_increments_eviction_count() {
         let mut cache = make_cache(2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
         assert_eq!(cache.segment.metrics().core.evictions, 0);
 
         // Inserting a 3rd item should evict one (capacity=2)
-        cache.put("c", 3, None);
+        cache.put("c", 3, 1);
         assert_eq!(cache.segment.metrics().core.evictions, 1);
 
         // Another insert should evict again
-        cache.put("d", 4, None);
+        cache.put("d", 4, 1);
         assert_eq!(cache.segment.metrics().core.evictions, 2);
     }
 
@@ -1480,11 +1479,11 @@ mod tests {
         let mut cache = make_cache(5);
 
         // Initial state: a(LRU) -> b -> c -> d -> e(MRU)
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
-        cache.put("e", 5, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
+        cache.put("e", 5, 1);
 
         // pop LRU: removes "a", order: b(LRU) -> c -> d -> e(MRU)
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1498,7 +1497,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f": c(LRU) -> d -> e -> f(MRU)
-        cache.put("f", 6, None);
+        cache.put("f", 6, 1);
         assert_eq!(cache.len(), 4);
 
         // pop LRU: removes "c", order: d(LRU) -> e -> f(MRU)

--- a/src/slru.rs
+++ b/src/slru.rs
@@ -133,9 +133,9 @@
 //! };
 //! let mut cache = SlruCache::init(config, None);
 //!
-//! cache.put("a", 1);  // Enters probationary
+//! cache.put("a", 1, None);  // Enters probationary
 //! cache.get(&"a");    // Promoted to protected!
-//! cache.put("b", 2);  // Enters probationary
+//! cache.put("b", 2, None);  // Enters probationary
 //!
 //! assert_eq!(cache.get(&"a"), Some(&1));  // Still in protected
 //! ```
@@ -156,13 +156,13 @@
 //!
 //! // Establish hot items in protected segment
 //! for key in [1, 2, 3] {
-//!     cache.put(key, 100);
+//!     cache.put(key, 100, None);
 //!     cache.get(&key);  // Promote to protected
 //! }
 //!
 //! // Simulate a scan - these items only enter probationary
 //! for i in 100..120 {
-//!     cache.put(i, i);  // One-time insertions
+//!     cache.put(i, i, None);  // One-time insertions
 //! }
 //!
 //! // Hot items survive the scan!
@@ -182,7 +182,6 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
-use core::mem;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "hashbrown")]
@@ -339,11 +338,6 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> SlruInner<K, V, S> {
     #[inline]
     pub(crate) fn max_size(&self) -> u64 {
         self.max_size
-    }
-
-    /// Estimates the size of a key-value pair in bytes for metrics tracking
-    fn estimate_object_size(&self, _key: &K, _value: &V) -> u64 {
-        mem::size_of::<K>() as u64 + mem::size_of::<V>() as u64 + 64
     }
 
     /// Returns a reference to the metrics for this segment.
@@ -566,19 +560,17 @@ impl<K: Hash + Eq, V: Clone, S: BuildHasher> SlruInner<K, V, S> {
 
 impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruInner<K, V, S> {
     /// Inserts a key-value pair into the segment.
-    pub(crate) fn put(&mut self, key: K, value: V) -> Option<(K, V)>
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to insert
+    /// * `size` - Optional size in bytes. If `None`, defaults to 1.
+    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         V: Clone,
     {
-        let object_size = self.estimate_object_size(&key, &value);
-        self.put_with_size(key, value, object_size)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
-    pub(crate) fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
-    where
-        V: Clone,
-    {
+        let size = size.unwrap_or(1);
         // If key is already in the cache, update it in place
         if let Some(&node) = self.map.get(&key) {
             unsafe {
@@ -749,7 +741,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruInner<K, V, S> {
     ///
     /// This method does **not** increment the eviction counter in metrics.
     /// Eviction metrics are only recorded when the cache internally evicts
-    /// entries to make room during `put()`/`put_with_size()` operations.
+    /// entries to make room during `put()` operations.
     pub(crate) fn pop(&mut self) -> Option<(K, V)> {
         // Try probationary first (normal eviction target)
         if let Some(old_entry) = self.probationary.remove_last() {
@@ -867,17 +859,17 @@ impl<K, V, S> core::fmt::Debug for SlruInner<K, V, S> {
 /// let mut cache = SlruCache::init(config, None);
 ///
 /// // Add some items
-/// cache.put("a", 1);
-/// cache.put("b", 2);
-/// cache.put("c", 3);
-/// cache.put("d", 4);
+/// cache.put("a", 1, None);
+/// cache.put("b", 2, None);
+/// cache.put("c", 3, None);
+/// cache.put("d", 4, None);
 ///
 /// // Access "a" to promote it to the protected segment
 /// assert_eq!(cache.get(&"a"), Some(&1));
 ///
 /// // Add a new item, which will evict the least recently used item
 /// // from the probationary segment (likely "b")
-/// cache.put("e", 5);
+/// cache.put("e", 5, None);
 /// assert_eq!(cache.get(&"b"), None);
 /// ```
 #[derive(Debug)]
@@ -974,6 +966,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///
     /// The inserted key-value pair is always placed in the probationary segment.
     ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to insert
+    /// * `size` - Optional size in bytes for size-aware caching. If `None`, defaults to 1.
+    ///
     /// # Multi-eviction behavior
     ///
     /// When using size-based caching (`max_size` is not `u64::MAX`), inserting
@@ -981,30 +979,11 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     /// free enough space. In this case, only the **last** evicted entry is
     /// returned. For count-based caches, at most one entry is evicted.
     #[inline]
-    pub fn put(&mut self, key: K, value: V) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
     where
         V: Clone,
     {
-        self.segment.put(key, value)
-    }
-
-    /// Insert a key-value pair with explicit size tracking.
-    ///
-    /// The `size` parameter specifies how much of `max_size` this entry consumes.
-    /// Use `size=1` for count-based caches.
-    ///
-    /// # Multi-eviction behavior
-    ///
-    /// When the new entry's size would exceed `max_size`, multiple existing
-    /// entries may be evicted to free enough space. Only the **last** evicted
-    /// entry is returned. All evicted entries are counted in the `evictions`
-    /// metric.
-    #[inline]
-    pub fn put_with_size(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
-    where
-        V: Clone,
-    {
-        self.segment.put_with_size(key, value, size)
+        self.segment.put(key, value, size)
     }
 
     /// Removes a key from the cache, returning the value at the key if the key was previously in the cache.
@@ -1046,7 +1025,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = SlruCache::init(config, None);
-    /// cache.put("a", 1);
+    /// cache.put("a", 1, None);
     /// assert!(cache.contains(&"a"));
     /// assert!(!cache.contains(&"b"));
     /// ```
@@ -1077,7 +1056,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = SlruCache::init(config, None);
-    /// cache.put("a", 1);
+    /// cache.put("a", 1, None);
     ///
     /// // peek does not promote between segments
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -1119,9 +1098,9 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = SlruCache::init(config, None);
-    /// cache.put("a", 1);
-    /// cache.put("b", 2);
-    /// cache.put("c", 3);
+    /// cache.put("a", 1, None);
+    /// cache.put("b", 2, None);
+    /// cache.put("c", 3, None);
     ///
     /// // Pop the eviction candidate (LRU from probationary)
     /// let popped = cache.pop();
@@ -1175,7 +1154,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: SlruCache<&str, i32> = SlruCache::init(config, None);
-    /// cache.put("key", 42);
+    /// cache.put("key", 42, None);
     ///
     /// // Cache with size limit
     /// let config = SlruCacheConfig {
@@ -1235,10 +1214,10 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items to fill probationary segment
-        assert_eq!(cache.put("a", 1), None);
-        assert_eq!(cache.put("b", 2), None);
-        assert_eq!(cache.put("c", 3), None);
-        assert_eq!(cache.put("d", 4), None);
+        assert_eq!(cache.put("a", 1, None), None);
+        assert_eq!(cache.put("b", 2, None), None);
+        assert_eq!(cache.put("c", 3, None), None);
+        assert_eq!(cache.put("d", 4, None), None);
 
         // Cache should be at capacity
         assert_eq!(cache.len(), 4);
@@ -1248,14 +1227,14 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Add a new item "e", should evict "c" from probationary
-        let evicted = cache.put("e", 5);
+        let evicted = cache.put("e", 5, None);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "c");
         assert_eq!(evicted_val, 3);
 
         // Add another item "f", should evict "d" from probationary
-        let evicted = cache.put("f", 6);
+        let evicted = cache.put("f", 6, None);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "d");
@@ -1276,15 +1255,15 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Access "a" to promote it to protected
         assert_eq!(cache.get(&"a"), Some(&1));
 
         // Update values
-        assert_eq!(cache.put("a", 10).unwrap().1, 1);
-        assert_eq!(cache.put("b", 20).unwrap().1, 2);
+        assert_eq!(cache.put("a", 10, None).unwrap().1, 1);
+        assert_eq!(cache.put("b", 20, None).unwrap().1, 2);
 
         // Check updated values
         assert_eq!(cache.get(&"a"), Some(&10));
@@ -1297,8 +1276,8 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Access "a" to promote it to protected
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1321,10 +1300,10 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
-        cache.put("d", 4);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
 
         // Clear the cache
         cache.clear();
@@ -1358,6 +1337,7 @@ mod tests {
                 id: 1,
                 data: "a-data".to_string(),
             },
+            None,
         );
         cache.put(
             "b",
@@ -1365,6 +1345,7 @@ mod tests {
                 id: 2,
                 data: "b-data".to_string(),
             },
+            None,
         );
 
         // Modify a value using get_mut
@@ -1388,18 +1369,18 @@ mod tests {
         assert_eq!(cache.protected_max_size().get(), 2);
 
         // Test basic functionality
-        assert_eq!(cache.put("a", 1), None);
-        assert_eq!(cache.put("b", 2), None);
+        assert_eq!(cache.put("a", 1, None), None);
+        assert_eq!(cache.put("b", 2, None), None);
 
         // Access "a" to promote it to protected
         assert_eq!(cache.get(&"a"), Some(&1));
 
         // Fill the cache
-        assert_eq!(cache.put("c", 3), None);
-        assert_eq!(cache.put("d", 4), None);
+        assert_eq!(cache.put("c", 3, None), None);
+        assert_eq!(cache.put("d", 4, None), None);
 
         // Add another item, should evict "b" from probationary
-        let result = cache.put("e", 5);
+        let result = cache.put("e", 5, None);
         assert_eq!(result.unwrap().0, "b");
 
         // Check that protected items remain
@@ -1422,8 +1403,8 @@ mod tests {
         assert_eq!(segment.cap().get(), 4);
         assert_eq!(segment.protected_max_size().get(), 2);
 
-        segment.put("a", 1);
-        segment.put("b", 2);
+        segment.put("a", 1, None);
+        segment.put("b", 2, None);
         assert_eq!(segment.len(), 2);
 
         // Access to promote
@@ -1450,7 +1431,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i);
+                    guard.put(key.clone(), i, None);
                     let _ = guard.get(&key);
                 }
             }));
@@ -1472,9 +1453,9 @@ mod tests {
         assert_eq!(cache.current_size(), 0);
         assert_eq!(cache.max_size(), u64::MAX);
 
-        cache.put_with_size("a", 1, 100);
-        cache.put_with_size("b", 2, 200);
-        cache.put_with_size("c", 3, 150);
+        cache.put("a", 1, Some(100));
+        cache.put("b", 2, Some(200));
+        cache.put("c", 3, Some(150));
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1529,7 +1510,7 @@ mod tests {
     fn test_slru_get_mut() {
         let mut cache: SlruCache<String, i32> = make_cache(100, 30);
 
-        cache.put("key".to_string(), 10);
+        cache.put("key".to_string(), 10, None);
         assert_eq!(cache.get(&"key".to_string()), Some(&10));
 
         // Modify via get_mut
@@ -1565,16 +1546,16 @@ mod tests {
         let mut cache = make_cache_with_max_size(100, 30, 100);
 
         // Insert items that fit within max_size
-        cache.put_with_size("a".to_string(), 1, 30); // total: 30
-        cache.put_with_size("b".to_string(), 2, 30); // total: 60
-        cache.put_with_size("c".to_string(), 3, 30); // total: 90
+        cache.put("a".to_string(), 1, Some(30)); // total: 30
+        cache.put("b".to_string(), 2, Some(30)); // total: 60
+        cache.put("c".to_string(), 3, Some(30)); // total: 90
 
         assert_eq!(cache.len(), 3, "Should have 3 items");
         assert_eq!(cache.current_size(), 90, "Size should be 90");
 
         // Insert item that would exceed max_size (90 + 20 = 110 > 100)
         // This SHOULD trigger eviction to stay within max_size
-        cache.put_with_size("d".to_string(), 4, 20);
+        cache.put("d".to_string(), 4, Some(20));
 
         // Cache should evict to stay within max_size
         // The LRU item ("a") should be evicted, leaving b, c, d
@@ -1600,14 +1581,14 @@ mod tests {
 
         // Insert objects that each take 100 bytes
         for i in 0..5 {
-            cache.put_with_size(format!("key{}", i), i, 100);
+            cache.put(format!("key{}", i), i, Some(100));
         }
 
         assert_eq!(cache.len(), 5);
         assert_eq!(cache.current_size(), 500, "Should have exactly 500 bytes");
 
         // Insert one more - should trigger eviction to stay within 500
-        cache.put_with_size("overflow".to_string(), 99, 100);
+        cache.put("overflow".to_string(), 99, Some(100));
 
         // Expected: oldest item evicted, size still <= 500
         assert!(
@@ -1622,8 +1603,8 @@ mod tests {
     fn test_slru_contains_non_promoting() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1633,8 +1614,8 @@ mod tests {
         // contains() should NOT promote entries
         // Both should still be in probationary
         // Adding "c" and "d" should fill probationary
-        cache.put("c", 3);
-        cache.put("d", 4);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
 
         // At this point all 4 items are in probationary (none accessed twice)
         assert_eq!(cache.len(), 4);
@@ -1646,9 +1627,9 @@ mod tests {
     fn test_slru_pop_returns_lru() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // All in probationary, order is: head=[c]→[b]→[a]=tail
         // pop() returns from tail (LRU), so order is: a, b, c
@@ -1669,9 +1650,9 @@ mod tests {
     fn test_slru_pop_r_returns_mru() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // All in probationary, order is: head=[c]→[b]→[a]=tail
         // pop_r() returns from head (MRU), so order is: c, b, a
@@ -1692,8 +1673,8 @@ mod tests {
     fn test_slru_pop_with_protected_entries() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // Access "a" and "b" to promote them to protected
         // get("a") → protected: head=[a]=tail, probationary: [b]
@@ -1704,8 +1685,8 @@ mod tests {
         // Add more items to probationary
         // put("c") → probationary: [c]
         // put("d") → probationary: head=[d]→[c]=tail
-        cache.put("c", 3);
-        cache.put("d", 4);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
 
         // State: protected=[b]→[a], probationary=[d]→[c]
         // pop() returns from probationary LRU (tail) = "c"
@@ -1718,7 +1699,7 @@ mod tests {
     #[test]
     fn test_slru_pop_single_element() {
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1728,7 +1709,7 @@ mod tests {
     #[test]
     fn test_slru_pop_r_single_element() {
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
+        cache.put("a", 1, None);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1739,8 +1720,8 @@ mod tests {
     fn test_slru_peek_non_promoting() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
-        cache.put("b", 2);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
 
         // peek() should return value without promoting
         assert_eq!(cache.peek(&"a"), Some(&1));
@@ -1752,8 +1733,8 @@ mod tests {
         cache.get(&"a");
 
         // Add "c" and "d" - if peek promoted, this would evict "a"
-        cache.put("c", 3);
-        cache.put("d", 4);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
 
         // "a" was promoted by get(), so it should still exist
         assert!(cache.contains(&"a"));
@@ -1762,9 +1743,9 @@ mod tests {
     #[test]
     fn test_slru_pop_does_not_inflate_eviction_count() {
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
 
         // Manual pop should NOT count as eviction
         assert!(cache.pop().is_some());
@@ -1783,11 +1764,11 @@ mod tests {
 
         // Insert entries: all start in probationary
         // Order in probationary: a(LRU) -> b -> c -> d -> e(MRU)
-        cache.put("a", 1);
-        cache.put("b", 2);
-        cache.put("c", 3);
-        cache.put("d", 4);
-        cache.put("e", 5);
+        cache.put("a", 1, None);
+        cache.put("b", 2, None);
+        cache.put("c", 3, None);
+        cache.put("d", 4, None);
+        cache.put("e", 5, None);
 
         // pop() removes LRU from probationary: "a"
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1802,7 +1783,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f"
-        cache.put("f", 6);
+        cache.put("f", 6, None);
         assert_eq!(cache.len(), 4);
 
         // Access "c" to promote it
@@ -1818,7 +1799,7 @@ mod tests {
         cache.remove(&"c");
 
         // Continue with mixed operations
-        cache.put("g", 7);
+        cache.put("g", 7, None);
         cache.get(&"g"); // promote g
 
         // Pop remaining entries

--- a/src/slru.rs
+++ b/src/slru.rs
@@ -133,9 +133,9 @@
 //! };
 //! let mut cache = SlruCache::init(config, None);
 //!
-//! cache.put("a", 1, None);  // Enters probationary
+//! cache.put("a", 1, 1);  // Enters probationary
 //! cache.get(&"a");    // Promoted to protected!
-//! cache.put("b", 2, None);  // Enters probationary
+//! cache.put("b", 2, 1);  // Enters probationary
 //!
 //! assert_eq!(cache.get(&"a"), Some(&1));  // Still in protected
 //! ```
@@ -156,13 +156,13 @@
 //!
 //! // Establish hot items in protected segment
 //! for key in [1, 2, 3] {
-//!     cache.put(key, 100, None);
+//!     cache.put(key, 100, 1);
 //!     cache.get(&key);  // Promote to protected
 //! }
 //!
 //! // Simulate a scan - these items only enter probationary
 //! for i in 100..120 {
-//!     cache.put(i, i, None);  // One-time insertions
+//!     cache.put(i, i, 1);  // One-time insertions
 //! }
 //!
 //! // Hot items survive the scan!
@@ -565,12 +565,11 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruInner<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `value` - The value to insert
-    /// * `size` - Optional size in bytes. If `None`, defaults to 1.
-    pub(crate) fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    /// * `size` - Optional size in bytes. Use `SIZE_UNIT` (1) for count-based caching.
+    pub(crate) fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         V: Clone,
     {
-        let size = size.unwrap_or(1);
         // If key is already in the cache, update it in place
         if let Some(&node) = self.map.get(&key) {
             unsafe {
@@ -859,17 +858,17 @@ impl<K, V, S> core::fmt::Debug for SlruInner<K, V, S> {
 /// let mut cache = SlruCache::init(config, None);
 ///
 /// // Add some items
-/// cache.put("a", 1, None);
-/// cache.put("b", 2, None);
-/// cache.put("c", 3, None);
-/// cache.put("d", 4, None);
+/// cache.put("a", 1, 1);
+/// cache.put("b", 2, 1);
+/// cache.put("c", 3, 1);
+/// cache.put("d", 4, 1);
 ///
 /// // Access "a" to promote it to the protected segment
 /// assert_eq!(cache.get(&"a"), Some(&1));
 ///
 /// // Add a new item, which will evict the least recently used item
 /// // from the probationary segment (likely "b")
-/// cache.put("e", 5, None);
+/// cache.put("e", 5, 1);
 /// assert_eq!(cache.get(&"b"), None);
 /// ```
 #[derive(Debug)]
@@ -970,7 +969,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///
     /// * `key` - The key to insert
     /// * `value` - The value to insert
-    /// * `size` - Optional size in bytes for size-aware caching. If `None`, defaults to 1.
+    /// * `size` - Optional size in bytes for size-aware caching. Use `SIZE_UNIT` (1) for count-based caching.
     ///
     /// # Multi-eviction behavior
     ///
@@ -979,7 +978,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     /// free enough space. In this case, only the **last** evicted entry is
     /// returned. For count-based caches, at most one entry is evicted.
     #[inline]
-    pub fn put(&mut self, key: K, value: V, size: Option<u64>) -> Option<(K, V)>
+    pub fn put(&mut self, key: K, value: V, size: u64) -> Option<(K, V)>
     where
         V: Clone,
     {
@@ -1025,7 +1024,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = SlruCache::init(config, None);
-    /// cache.put("a", 1, None);
+    /// cache.put("a", 1, 1);
     /// assert!(cache.contains(&"a"));
     /// assert!(!cache.contains(&"b"));
     /// ```
@@ -1056,7 +1055,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = SlruCache::init(config, None);
-    /// cache.put("a", 1, None);
+    /// cache.put("a", 1, 1);
     ///
     /// // peek does not promote between segments
     /// assert_eq!(cache.peek(&"a"), Some(&1));
@@ -1098,9 +1097,9 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> SlruCache<K, V, S> {
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache = SlruCache::init(config, None);
-    /// cache.put("a", 1, None);
-    /// cache.put("b", 2, None);
-    /// cache.put("c", 3, None);
+    /// cache.put("a", 1, 1);
+    /// cache.put("b", 2, 1);
+    /// cache.put("c", 3, 1);
     ///
     /// // Pop the eviction candidate (LRU from probationary)
     /// let popped = cache.pop();
@@ -1154,7 +1153,7 @@ where
     ///     max_size: u64::MAX,
     /// };
     /// let mut cache: SlruCache<&str, i32> = SlruCache::init(config, None);
-    /// cache.put("key", 42, None);
+    /// cache.put("key", 42, 1);
     ///
     /// // Cache with size limit
     /// let config = SlruCacheConfig {
@@ -1214,10 +1213,10 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items to fill probationary segment
-        assert_eq!(cache.put("a", 1, None), None);
-        assert_eq!(cache.put("b", 2, None), None);
-        assert_eq!(cache.put("c", 3, None), None);
-        assert_eq!(cache.put("d", 4, None), None);
+        assert_eq!(cache.put("a", 1, 1), None);
+        assert_eq!(cache.put("b", 2, 1), None);
+        assert_eq!(cache.put("c", 3, 1), None);
+        assert_eq!(cache.put("d", 4, 1), None);
 
         // Cache should be at capacity
         assert_eq!(cache.len(), 4);
@@ -1227,14 +1226,14 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&2));
 
         // Add a new item "e", should evict "c" from probationary
-        let evicted = cache.put("e", 5, None);
+        let evicted = cache.put("e", 5, 1);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "c");
         assert_eq!(evicted_val, 3);
 
         // Add another item "f", should evict "d" from probationary
-        let evicted = cache.put("f", 6, None);
+        let evicted = cache.put("f", 6, 1);
         assert!(evicted.is_some());
         let (evicted_key, evicted_val) = evicted.unwrap();
         assert_eq!(evicted_key, "d");
@@ -1255,15 +1254,15 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Access "a" to promote it to protected
         assert_eq!(cache.get(&"a"), Some(&1));
 
         // Update values
-        assert_eq!(cache.put("a", 10, None).unwrap().1, 1);
-        assert_eq!(cache.put("b", 20, None).unwrap().1, 2);
+        assert_eq!(cache.put("a", 10, 1).unwrap().1, 1);
+        assert_eq!(cache.put("b", 20, 1).unwrap().1, 2);
 
         // Check updated values
         assert_eq!(cache.get(&"a"), Some(&10));
@@ -1276,8 +1275,8 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Access "a" to promote it to protected
         assert_eq!(cache.get(&"a"), Some(&1));
@@ -1300,10 +1299,10 @@ mod tests {
         let mut cache = make_cache(4, 2);
 
         // Add items
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
 
         // Clear the cache
         cache.clear();
@@ -1337,7 +1336,7 @@ mod tests {
                 id: 1,
                 data: "a-data".to_string(),
             },
-            None,
+            1,
         );
         cache.put(
             "b",
@@ -1345,7 +1344,7 @@ mod tests {
                 id: 2,
                 data: "b-data".to_string(),
             },
-            None,
+            1,
         );
 
         // Modify a value using get_mut
@@ -1369,18 +1368,18 @@ mod tests {
         assert_eq!(cache.protected_max_size().get(), 2);
 
         // Test basic functionality
-        assert_eq!(cache.put("a", 1, None), None);
-        assert_eq!(cache.put("b", 2, None), None);
+        assert_eq!(cache.put("a", 1, 1), None);
+        assert_eq!(cache.put("b", 2, 1), None);
 
         // Access "a" to promote it to protected
         assert_eq!(cache.get(&"a"), Some(&1));
 
         // Fill the cache
-        assert_eq!(cache.put("c", 3, None), None);
-        assert_eq!(cache.put("d", 4, None), None);
+        assert_eq!(cache.put("c", 3, 1), None);
+        assert_eq!(cache.put("d", 4, 1), None);
 
         // Add another item, should evict "b" from probationary
-        let result = cache.put("e", 5, None);
+        let result = cache.put("e", 5, 1);
         assert_eq!(result.unwrap().0, "b");
 
         // Check that protected items remain
@@ -1403,8 +1402,8 @@ mod tests {
         assert_eq!(segment.cap().get(), 4);
         assert_eq!(segment.protected_max_size().get(), 2);
 
-        segment.put("a", 1, None);
-        segment.put("b", 2, None);
+        segment.put("a", 1, 1);
+        segment.put("b", 2, 1);
         assert_eq!(segment.len(), 2);
 
         // Access to promote
@@ -1431,7 +1430,7 @@ mod tests {
                 for i in 0..ops_per_thread {
                     let key = std::format!("key_{}_{}", t, i);
                     let mut guard = cache.lock().unwrap();
-                    guard.put(key.clone(), i, None);
+                    guard.put(key.clone(), i, 1);
                     let _ = guard.get(&key);
                 }
             }));
@@ -1453,9 +1452,9 @@ mod tests {
         assert_eq!(cache.current_size(), 0);
         assert_eq!(cache.max_size(), u64::MAX);
 
-        cache.put("a", 1, Some(100));
-        cache.put("b", 2, Some(200));
-        cache.put("c", 3, Some(150));
+        cache.put("a", 1, 100);
+        cache.put("b", 2, 200);
+        cache.put("c", 3, 150);
 
         assert_eq!(cache.current_size(), 450);
         assert_eq!(cache.len(), 3);
@@ -1510,7 +1509,7 @@ mod tests {
     fn test_slru_get_mut() {
         let mut cache: SlruCache<String, i32> = make_cache(100, 30);
 
-        cache.put("key".to_string(), 10, None);
+        cache.put("key".to_string(), 10, 1);
         assert_eq!(cache.get(&"key".to_string()), Some(&10));
 
         // Modify via get_mut
@@ -1546,16 +1545,16 @@ mod tests {
         let mut cache = make_cache_with_max_size(100, 30, 100);
 
         // Insert items that fit within max_size
-        cache.put("a".to_string(), 1, Some(30)); // total: 30
-        cache.put("b".to_string(), 2, Some(30)); // total: 60
-        cache.put("c".to_string(), 3, Some(30)); // total: 90
+        cache.put("a".to_string(), 1, 30); // total: 30
+        cache.put("b".to_string(), 2, 30); // total: 60
+        cache.put("c".to_string(), 3, 30); // total: 90
 
         assert_eq!(cache.len(), 3, "Should have 3 items");
         assert_eq!(cache.current_size(), 90, "Size should be 90");
 
         // Insert item that would exceed max_size (90 + 20 = 110 > 100)
         // This SHOULD trigger eviction to stay within max_size
-        cache.put("d".to_string(), 4, Some(20));
+        cache.put("d".to_string(), 4, 20);
 
         // Cache should evict to stay within max_size
         // The LRU item ("a") should be evicted, leaving b, c, d
@@ -1581,14 +1580,14 @@ mod tests {
 
         // Insert objects that each take 100 bytes
         for i in 0..5 {
-            cache.put(format!("key{}", i), i, Some(100));
+            cache.put(format!("key{}", i), i, 100);
         }
 
         assert_eq!(cache.len(), 5);
         assert_eq!(cache.current_size(), 500, "Should have exactly 500 bytes");
 
         // Insert one more - should trigger eviction to stay within 500
-        cache.put("overflow".to_string(), 99, Some(100));
+        cache.put("overflow".to_string(), 99, 100);
 
         // Expected: oldest item evicted, size still <= 500
         assert!(
@@ -1603,8 +1602,8 @@ mod tests {
     fn test_slru_contains_non_promoting() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // contains() should return true for existing keys
         assert!(cache.contains(&"a"));
@@ -1614,8 +1613,8 @@ mod tests {
         // contains() should NOT promote entries
         // Both should still be in probationary
         // Adding "c" and "d" should fill probationary
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
 
         // At this point all 4 items are in probationary (none accessed twice)
         assert_eq!(cache.len(), 4);
@@ -1627,9 +1626,9 @@ mod tests {
     fn test_slru_pop_returns_lru() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // All in probationary, order is: head=[c]→[b]→[a]=tail
         // pop() returns from tail (LRU), so order is: a, b, c
@@ -1650,9 +1649,9 @@ mod tests {
     fn test_slru_pop_r_returns_mru() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // All in probationary, order is: head=[c]→[b]→[a]=tail
         // pop_r() returns from head (MRU), so order is: c, b, a
@@ -1673,8 +1672,8 @@ mod tests {
     fn test_slru_pop_with_protected_entries() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // Access "a" and "b" to promote them to protected
         // get("a") → protected: head=[a]=tail, probationary: [b]
@@ -1685,8 +1684,8 @@ mod tests {
         // Add more items to probationary
         // put("c") → probationary: [c]
         // put("d") → probationary: head=[d]→[c]=tail
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
 
         // State: protected=[b]→[a], probationary=[d]→[c]
         // pop() returns from probationary LRU (tail) = "c"
@@ -1699,7 +1698,7 @@ mod tests {
     #[test]
     fn test_slru_pop_single_element() {
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop();
         assert_eq!(popped, Some(("a", 1)));
@@ -1709,7 +1708,7 @@ mod tests {
     #[test]
     fn test_slru_pop_r_single_element() {
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
+        cache.put("a", 1, 1);
 
         let popped = cache.pop_r();
         assert_eq!(popped, Some(("a", 1)));
@@ -1720,8 +1719,8 @@ mod tests {
     fn test_slru_peek_non_promoting() {
         // Create cache: 4 total (2 probationary, 2 protected)
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
 
         // peek() should return value without promoting
         assert_eq!(cache.peek(&"a"), Some(&1));
@@ -1733,8 +1732,8 @@ mod tests {
         cache.get(&"a");
 
         // Add "c" and "d" - if peek promoted, this would evict "a"
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
 
         // "a" was promoted by get(), so it should still exist
         assert!(cache.contains(&"a"));
@@ -1743,9 +1742,9 @@ mod tests {
     #[test]
     fn test_slru_pop_does_not_inflate_eviction_count() {
         let mut cache = make_cache(4, 2);
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
 
         // Manual pop should NOT count as eviction
         assert!(cache.pop().is_some());
@@ -1764,11 +1763,11 @@ mod tests {
 
         // Insert entries: all start in probationary
         // Order in probationary: a(LRU) -> b -> c -> d -> e(MRU)
-        cache.put("a", 1, None);
-        cache.put("b", 2, None);
-        cache.put("c", 3, None);
-        cache.put("d", 4, None);
-        cache.put("e", 5, None);
+        cache.put("a", 1, 1);
+        cache.put("b", 2, 1);
+        cache.put("c", 3, 1);
+        cache.put("d", 4, 1);
+        cache.put("e", 5, 1);
 
         // pop() removes LRU from probationary: "a"
         assert_eq!(cache.pop(), Some(("a", 1)));
@@ -1783,7 +1782,7 @@ mod tests {
         assert_eq!(cache.len(), 3);
 
         // Put new entry "f"
-        cache.put("f", 6, None);
+        cache.put("f", 6, 1);
         assert_eq!(cache.len(), 4);
 
         // Access "c" to promote it
@@ -1799,7 +1798,7 @@ mod tests {
         cache.remove(&"c");
 
         // Continue with mixed operations
-        cache.put("g", 7, None);
+        cache.put("g", 7, 1);
         cache.get(&"g"); // promote g
 
         // Pop remaining entries

--- a/tests/concurrent_correctness_tests.rs
+++ b/tests/concurrent_correctness_tests.rs
@@ -190,7 +190,7 @@ fn test_concurrent_lru_basic_eviction() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Mixed operations simulating real-world usage
-                c.put(key, key * 10, None);
+                c.put(key, key * 10, 1);
                 let _ = c.get(&key);
                 if i % 5 == 0 {
                     let _ = c.contains(&key);
@@ -224,7 +224,7 @@ fn test_concurrent_lru_access_prevents_eviction() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100, None);
+        cache.put(key, key * 100, 1);
     }
 
     let mut handles = vec![];
@@ -242,7 +242,7 @@ fn test_concurrent_lru_access_prevents_eviction() {
 
                 // Also insert new cold keys that may get evicted
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
-                c.put(cold_key, cold_key, None);
+                c.put(cold_key, cold_key, 1);
 
                 // Realistic operations mix
                 if i % 3 == 0 {
@@ -279,7 +279,7 @@ fn test_concurrent_lru_multi_segment_eviction() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Real-world pattern: put, then read multiple times
-                c.put(key, key * 10, None);
+                c.put(key, key * 10, 1);
                 for _ in 0..3 {
                     let _ = c.get(&key);
                 }
@@ -315,7 +315,7 @@ fn test_concurrent_lru_concurrent_writes_maintain_capacity() {
         handles.push(thread::spawn(move || {
             for i in 0..100 {
                 let key = t * 1000 + i;
-                cache.put(key, key, None);
+                cache.put(key, key, 1);
             }
         }));
     }
@@ -345,7 +345,7 @@ fn test_concurrent_lfu_frequency_based_eviction() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100, None);
+        cache.put(key, key * 100, 1);
     }
 
     let mut handles = vec![];
@@ -365,7 +365,7 @@ fn test_concurrent_lfu_frequency_based_eviction() {
 
                 // Insert cold keys that should get evicted due to low frequency
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
-                c.put(cold_key, cold_key, None);
+                c.put(cold_key, cold_key, 1);
 
                 // Realistic mix: peek doesn't update frequency
                 if i % 5 == 0 {
@@ -393,9 +393,9 @@ fn test_concurrent_lfu_frequency_accumulation() {
         Arc::new(ConcurrentLfuCache::init(lfu_config(6, 2), None));
 
     // Insert items
-    cache.put("hot".to_string(), 1, None);
-    cache.put("warm".to_string(), 2, None);
-    cache.put("cold".to_string(), 3, None);
+    cache.put("hot".to_string(), 1, 1);
+    cache.put("warm".to_string(), 2, 1);
+    cache.put("cold".to_string(), 3, 1);
 
     let cache_clone = Arc::clone(&cache);
 
@@ -416,10 +416,10 @@ fn test_concurrent_lfu_frequency_accumulation() {
 
     // "hot" should have very high frequency now
     // Fill cache to trigger eviction
-    cache_clone.put("new1".to_string(), 4, None);
-    cache_clone.put("new2".to_string(), 5, None);
-    cache_clone.put("new3".to_string(), 6, None);
-    cache_clone.put("new4".to_string(), 7, None);
+    cache_clone.put("new1".to_string(), 4, 1);
+    cache_clone.put("new2".to_string(), 5, 1);
+    cache_clone.put("new3".to_string(), 6, 1);
+    cache_clone.put("new4".to_string(), 7, 1);
 
     // "hot" should survive due to high frequency
     assert!(
@@ -442,7 +442,7 @@ fn test_concurrent_lfu_multi_segment_correctness() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Put and then access to build frequency
-                c.put(key, key * 10, None);
+                c.put(key, key * 10, 1);
 
                 // Access some keys more to increase frequency
                 if key % 10 < 3 {
@@ -488,7 +488,7 @@ fn test_concurrent_lfuda_priority_eviction() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100, None);
+        cache.put(key, key * 100, 1);
     }
 
     let mut handles = vec![];
@@ -508,7 +508,7 @@ fn test_concurrent_lfuda_priority_eviction() {
 
                 // Insert cold keys that may get evicted
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
-                c.put(cold_key, cold_key, None);
+                c.put(cold_key, cold_key, 1);
 
                 // Mix in other operations
                 if i % 5 == 0 {
@@ -545,7 +545,7 @@ fn test_concurrent_lfuda_aging_mechanism() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 10, None);
+                c.put(key, key * 10, 1);
 
                 // Access some keys to build priority
                 if i % 3 == 0 {
@@ -591,7 +591,7 @@ fn test_concurrent_slru_segment_behavior() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Items start in probationary
-                c.put(key, key * 10, None);
+                c.put(key, key * 10, 1);
 
                 // Access multiple times to promote to protected
                 if i % 3 == 0 {
@@ -629,7 +629,7 @@ fn test_concurrent_slru_promotion_under_concurrency() {
 
     // Pre-populate with items
     for i in 0..20 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
 
     let mut handles = vec![];
@@ -640,7 +640,7 @@ fn test_concurrent_slru_promotion_under_concurrency() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 10, None);
+                c.put(key, key * 10, 1);
 
                 // Access repeatedly to promote to protected
                 for _ in 0..4 {
@@ -688,7 +688,7 @@ fn test_concurrent_gdsf_size_aware_eviction() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Vary sizes: small objects should have higher priority
                 let size = if i % 5 == 0 { 100 } else { 1 }; // Large vs small
-                c.put(key, key * 10, Some(size));
+                c.put(key, key * 10, size);
 
                 // Access to build frequency
                 if i % 3 == 0 {
@@ -726,7 +726,7 @@ fn test_concurrent_gdsf_frequency_matters() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100, Some(1));
+        cache.put(key, key * 100, 1);
     }
 
     let mut handles = vec![];
@@ -747,7 +747,7 @@ fn test_concurrent_gdsf_frequency_matters() {
                 // Insert cold keys
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
                 let size = ((i % 10) + 1) as u64;
-                c.put(cold_key, cold_key, Some(size));
+                c.put(cold_key, cold_key, size);
 
                 // Mixed operations
                 if i % 5 == 0 {
@@ -785,7 +785,7 @@ fn test_concurrent_gdsf_concurrent_size_tracking() {
             for i in 0..5 {
                 let key = t * 10 + i;
                 let size = ((i + 1) * 10) as u64;
-                c.put(key, key, Some(size));
+                c.put(key, key, size);
             }
         }));
     }
@@ -824,7 +824,7 @@ fn test_capacity_never_exceeded_lru() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 wc.fetch_add(1, Ordering::Relaxed);
 
                 // Check invariant during operation
@@ -857,7 +857,7 @@ fn test_capacity_never_exceeded_lfu() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -885,7 +885,7 @@ fn test_capacity_never_exceeded_slru() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -911,7 +911,7 @@ fn test_capacity_never_exceeded_lfuda() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -937,7 +937,7 @@ fn test_capacity_never_exceeded_gdsf() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key, Some(1));
+                c.put(key, key, 1);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -961,7 +961,7 @@ fn test_get_returns_correct_value() {
 
     // Insert known values
     for i in 0..50 {
-        cache.put(i, i * 100, None);
+        cache.put(i, i * 100, 1);
     }
 
     let errors = Arc::new(AtomicUsize::new(0));
@@ -994,7 +994,7 @@ fn test_update_is_atomic() {
     let cache: Arc<ConcurrentLruCache<i32, i32>> =
         Arc::new(ConcurrentLruCache::init(lru_config(10, 2), None));
 
-    cache.put(1, 0, None);
+    cache.put(1, 0, 1);
 
     let mut handles = vec![];
 
@@ -1003,7 +1003,7 @@ fn test_update_is_atomic() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for _ in 0..100 {
-                c.put(1, t, None);
+                c.put(1, t, 1);
             }
         }));
     }
@@ -1030,7 +1030,7 @@ fn test_remove_consistency() {
 
     // Insert items
     for i in 0..50 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     // Verify all items were inserted before attempting removes
@@ -1082,7 +1082,7 @@ fn test_mixed_operations_lru() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..200 {
-                c.put(t * 1000 + i, i, None);
+                c.put(t * 1000 + i, i, 1);
             }
         }));
     }
@@ -1126,7 +1126,7 @@ fn test_mixed_operations_lfu() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..200 {
-                c.put(t * 1000 + i, i, None);
+                c.put(t * 1000 + i, i, 1);
                 let _ = c.get(&(t * 1000 + i));
             }
         }));
@@ -1150,7 +1150,7 @@ fn test_mixed_operations_slru() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..200 {
-                c.put(t * 1000 + i, i, None);
+                c.put(t * 1000 + i, i, 1);
                 // Access multiple times to trigger promotion
                 for _ in 0..3 {
                     let _ = c.get(&(t * 1000 + i));
@@ -1178,7 +1178,7 @@ fn test_mixed_operations_gdsf() {
         handles.push(thread::spawn(move || {
             for i in 0..200 {
                 let size = (i % 10 + 1) as u64;
-                c.put(t * 1000 + i, i, Some(size));
+                c.put(t * 1000 + i, i, size);
                 let _ = c.get(&(t * 1000 + i));
             }
         }));
@@ -1210,7 +1210,7 @@ fn test_clear_during_operations() {
         handles.push(thread::spawn(move || {
             let mut i = 0;
             while sf.load(Ordering::Relaxed) == 0 {
-                c.put(t * 10000 + i, i, None);
+                c.put(t * 10000 + i, i, 1);
                 i += 1;
             }
         }));
@@ -1254,7 +1254,7 @@ fn test_size_tracking_concurrent_lru() {
         handles.push(thread::spawn(move || {
             for i in 0..25 {
                 let key = t * 100 + i;
-                c.put(key, format!("value_{}", key), Some(10));
+                c.put(key, format!("value_{}", key), 10);
             }
         }));
     }
@@ -1286,7 +1286,7 @@ fn test_size_tracking_concurrent_lfu() {
         handles.push(thread::spawn(move || {
             for i in 0..25 {
                 let key = t * 100 + i;
-                c.put(key, format!("value_{}", key), Some(10));
+                c.put(key, format!("value_{}", key), 10);
             }
         }));
     }
@@ -1343,7 +1343,7 @@ fn test_concurrent_single_key() {
         let gc = Arc::clone(&get_count);
         handles.push(thread::spawn(move || {
             for i in 0..100 {
-                c.put(1, i, None);
+                c.put(1, i, 1);
                 pc.fetch_add(1, Ordering::Relaxed);
                 if c.get(&1).is_some() {
                     gc.fetch_add(1, Ordering::Relaxed);
@@ -1373,7 +1373,7 @@ fn test_concurrent_capacity_one() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..100 {
-                c.put(t * 100 + i, i, None);
+                c.put(t * 100 + i, i, 1);
             }
         }));
     }
@@ -1393,7 +1393,7 @@ fn test_contains_key_consistency() {
 
     // Insert known keys
     for i in 0..30 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     let mut handles = vec![];
@@ -1449,11 +1449,11 @@ fn test_all_concurrent_caches_len_consistency() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Mixed operations on all cache types
-                lru_c.put(key, key, None);
-                lfu_c.put(key, key, None);
-                lfuda_c.put(key, key, None);
-                slru_c.put(key, key, None);
-                gdsf_c.put(key, key, Some(1));
+                lru_c.put(key, key, 1);
+                lfu_c.put(key, key, 1);
+                lfuda_c.put(key, key, 1);
+                slru_c.put(key, key, 1);
+                gdsf_c.put(key, key, 1);
 
                 if i % 3 == 0 {
                     let _ = lru_c.get(&key);
@@ -1510,11 +1510,11 @@ fn test_all_concurrent_caches_clear() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                lru_c.put(key, key, None);
-                lfu_c.put(key, key, None);
-                lfuda_c.put(key, key, None);
-                slru_c.put(key, key, None);
-                gdsf_c.put(key, key, Some(1));
+                lru_c.put(key, key, 1);
+                lfu_c.put(key, key, 1);
+                lfuda_c.put(key, key, 1);
+                slru_c.put(key, key, 1);
+                gdsf_c.put(key, key, 1);
 
                 // Periodically clear all caches (simulates cache reset)
                 if i % 100 == 0 {
@@ -1574,7 +1574,7 @@ fn test_concurrent_lru_size_based_eviction() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(object_size));
+                c.put(key, format!("value_{}", key), object_size);
 
                 // Mixed operations
                 if i % 3 == 0 {
@@ -1627,7 +1627,7 @@ fn test_concurrent_lfu_size_based_eviction() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(object_size));
+                c.put(key, format!("value_{}", key), object_size);
 
                 // Build frequency on some keys
                 if i % 5 == 0 {
@@ -1680,7 +1680,7 @@ fn test_concurrent_lfuda_size_based_eviction() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(object_size));
+                c.put(key, format!("value_{}", key), object_size);
 
                 // Build priority on some keys
                 if i % 4 == 0 {
@@ -1737,7 +1737,7 @@ fn test_concurrent_gdsf_size_based_eviction() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Vary sizes to test GDSF's size-aware eviction
                 let size = ((i % 5) + 1) as u64 * 256; // 256 to 1280 bytes
-                c.put(key, format!("value_{}", key), Some(size));
+                c.put(key, format!("value_{}", key), size);
 
                 // Build frequency on some keys
                 if i % 3 == 0 {
@@ -1791,7 +1791,7 @@ fn test_concurrent_lru_per_segment_size_limit() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Use varying large object sizes
                 let size = ((i % 4) + 1) as u64 * 2048; // 2KB to 8KB
-                c.put(key, format!("large_value_{}", key), Some(size));
+                c.put(key, format!("large_value_{}", key), size);
 
                 // Verify size limits during concurrent access
                 let current = c.current_size();
@@ -1847,7 +1847,7 @@ fn test_concurrent_size_tracking_accuracy() {
             std::thread::spawn(move || {
                 for i in 0..25 {
                     let key = t * 25 + i;
-                    cache.put(key, format!("value_{}", key), Some(item_size));
+                    cache.put(key, format!("value_{}", key), item_size);
                 }
             })
         })
@@ -1889,7 +1889,7 @@ fn test_concurrent_size_tracking_on_remove() {
 
     // Pre-populate cache
     for i in 0..100 {
-        cache.put(i, format!("value_{}", i), Some(item_size));
+        cache.put(i, format!("value_{}", i), item_size);
     }
 
     let size_before = cache.current_size();
@@ -1910,7 +1910,7 @@ fn test_concurrent_size_tracking_on_remove() {
                 }
 
                 // Add new keys
-                c.put(key + 1000, format!("new_value_{}", key), Some(item_size));
+                c.put(key + 1000, format!("new_value_{}", key), item_size);
 
                 // Mixed operations
                 if i % 3 == 0 {
@@ -1975,7 +1975,7 @@ fn test_concurrent_lru_with_max_size() {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
                 let data = vec![0u8; 100];
-                c.put(key.clone(), data, Some(100));
+                c.put(key.clone(), data, 100);
 
                 if i % 3 == 0 {
                     let _ = c.get(&key);
@@ -2014,7 +2014,7 @@ fn test_concurrent_lru_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(100));
+                c.put(key, format!("value_{}", key), 100);
 
                 // Periodically clear to test clear under concurrency
                 if i % 50 == 0 {
@@ -2063,7 +2063,7 @@ fn test_concurrent_lfu_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put(key.clone(), vec![1, 2, 3], Some(100));
+                c.put(key.clone(), vec![1, 2, 3], 100);
                 if i % 3 == 0 {
                     let _ = c.get(&key);
                 }
@@ -2093,7 +2093,7 @@ fn test_concurrent_lfu_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(100));
+                c.put(key, format!("value_{}", key), 100);
                 if i % 50 == 0 {
                     c.clear();
                 }
@@ -2139,7 +2139,7 @@ fn test_concurrent_lfuda_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put(key.clone(), vec![1, 2, 3], Some(100));
+                c.put(key.clone(), vec![1, 2, 3], 100);
                 if i % 3 == 0 {
                     let _ = c.get(&key);
                 }
@@ -2169,7 +2169,7 @@ fn test_concurrent_lfuda_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(100));
+                c.put(key, format!("value_{}", key), 100);
                 if i % 50 == 0 {
                     c.clear();
                 }
@@ -2215,7 +2215,7 @@ fn test_concurrent_gdsf_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put(key.clone(), vec![1, 2, 3], Some(100));
+                c.put(key.clone(), vec![1, 2, 3], 100);
                 if i % 3 == 0 {
                     let _ = c.get(&key);
                 }
@@ -2245,7 +2245,7 @@ fn test_concurrent_gdsf_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(100));
+                c.put(key, format!("value_{}", key), 100);
                 if i % 50 == 0 {
                     c.clear();
                 }
@@ -2291,7 +2291,7 @@ fn test_concurrent_slru_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put(key.clone(), vec![1, 2, 3], Some(100));
+                c.put(key.clone(), vec![1, 2, 3], 100);
                 // Access multiple times to test promotion
                 for _ in 0..3 {
                     let _ = c.get(&key);
@@ -2322,7 +2322,7 @@ fn test_concurrent_slru_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), Some(100));
+                c.put(key, format!("value_{}", key), 100);
                 // Access to trigger promotion to protected
                 for _ in 0..3 {
                     let _ = c.get(&key);
@@ -2354,7 +2354,7 @@ fn test_concurrent_clear_during_operations() {
 
     // Pre-fill
     for i in 0..100 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
     assert_eq!(cache.len(), 100);
 
@@ -2372,7 +2372,7 @@ fn test_concurrent_clear_during_operations() {
 
     // Insert while clear is happening
     for i in 100..200 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     handle.join().unwrap();
@@ -2403,7 +2403,7 @@ fn test_concurrent_lru_record_miss() {
 
                 // Also do actual cache operations
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 let _ = c.get(&key);
             }
         }));
@@ -2439,7 +2439,7 @@ fn test_concurrent_lru_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2, None);
+                c.put(key, key * 2, 1);
                 // Use get_with to transform value - may be None if evicted
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2470,7 +2470,7 @@ fn test_concurrent_lfu_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2, None);
+                c.put(key, key * 2, 1);
                 // Use get_with to transform value - may be None if evicted
                 let doubled = c.get_with(&key, |v| v * 2);
                 // Value could be evicted by another thread, so it may be None
@@ -2502,7 +2502,7 @@ fn test_concurrent_lfuda_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2, None);
+                c.put(key, key * 2, 1);
                 // Value could be evicted by another thread, so it may be None
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2532,7 +2532,7 @@ fn test_concurrent_slru_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2, None);
+                c.put(key, key * 2, 1);
                 // Value could be evicted by another thread
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2562,7 +2562,7 @@ fn test_concurrent_gdsf_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2, Some(1));
+                c.put(key, key * 2, 1);
                 // Value could be evicted by another thread
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2596,7 +2596,7 @@ fn test_concurrent_lru_get_mut_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 // Use get_mut_with to mutate value in-place - may be None if evicted
                 let old_val = c.get_mut_with(&key, |v| {
                     let old = *v;
@@ -2652,35 +2652,35 @@ fn test_concurrent_all_caches_contains() {
                 // Note: We can't assert contains() results in concurrent tests because
                 // another thread may evict entries at any time between put and contains
                 let _ = lru_c.contains(&key);
-                lru_c.put(key, key, None);
+                lru_c.put(key, key, 1);
                 let _ = lru_c.contains(&key); // May be false if evicted by another thread
                 if i % 10 == 0 {
                     lru_c.remove(&key);
                 }
 
                 // LFU
-                lfu_c.put(key, key, None);
+                lfu_c.put(key, key, 1);
                 let _ = lfu_c.contains(&key);
                 if i % 10 == 0 {
                     lfu_c.remove(&key);
                 }
 
                 // LFUDA
-                lfuda_c.put(key, key, None);
+                lfuda_c.put(key, key, 1);
                 let _ = lfuda_c.contains(&key);
                 if i % 10 == 0 {
                     lfuda_c.remove(&key);
                 }
 
                 // SLRU
-                slru_c.put(key, key, None);
+                slru_c.put(key, key, 1);
                 let _ = slru_c.contains(&key);
                 if i % 10 == 0 {
                     slru_c.remove(&key);
                 }
 
                 // GDSF
-                gdsf_c.put(key, key, Some(1));
+                gdsf_c.put(key, key, 1);
                 let _ = gdsf_c.contains(&key);
                 if i % 10 == 0 {
                     gdsf_c.remove(&key);
@@ -2710,7 +2710,7 @@ fn test_concurrent_lru_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 // peek returns cloned value - may be None if evicted
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2741,7 +2741,7 @@ fn test_concurrent_lfu_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 // Value could be evicted by another thread
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2771,7 +2771,7 @@ fn test_concurrent_lfuda_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 // Value could be evicted by another thread
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2801,7 +2801,7 @@ fn test_concurrent_slru_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, None);
+                c.put(key, key, 1);
                 // Value could be evicted by another thread, so it may be None
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2831,7 +2831,7 @@ fn test_concurrent_gdsf_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, Some(1));
+                c.put(key, key, 1);
                 // Value could be evicted by another thread
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2860,7 +2860,7 @@ fn test_concurrent_lru_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     let mut handles = vec![];
@@ -2874,7 +2874,7 @@ fn test_concurrent_lru_pop() {
                 // Popped might be Some or None depending on cache state
                 if let Some((k, _v)) = popped {
                     // Put something back
-                    c.put(k + 10000, k, None);
+                    c.put(k + 10000, k, 1);
                 }
             }
         }));
@@ -2895,7 +2895,7 @@ fn test_concurrent_lfu_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     let mut handles = vec![];
@@ -2906,7 +2906,7 @@ fn test_concurrent_lfu_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k, None);
+                    c.put(k + 10000, k, 1);
                 }
             }
         }));
@@ -2926,7 +2926,7 @@ fn test_concurrent_lfuda_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     let mut handles = vec![];
@@ -2937,7 +2937,7 @@ fn test_concurrent_lfuda_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k, None);
+                    c.put(k + 10000, k, 1);
                 }
             }
         }));
@@ -2957,7 +2957,7 @@ fn test_concurrent_slru_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     let mut handles = vec![];
@@ -2968,7 +2968,7 @@ fn test_concurrent_slru_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k, None);
+                    c.put(k + 10000, k, 1);
                 }
             }
         }));
@@ -2988,7 +2988,7 @@ fn test_concurrent_gdsf_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i, Some(1));
+        cache.put(i, i, 1);
     }
 
     let mut handles = vec![];
@@ -2999,7 +2999,7 @@ fn test_concurrent_gdsf_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k, Some(1));
+                    c.put(k + 10000, k, 1);
                 }
             }
         }));
@@ -3043,23 +3043,23 @@ fn test_concurrent_all_caches_capacity_and_segments() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
 
                 // Perform operations while checking capacity/segments
-                lru_c.put(key, key, None);
+                lru_c.put(key, key, 1);
                 assert_eq!(lru_c.capacity(), 1000);
                 assert_eq!(lru_c.segment_count(), 4);
 
-                lfu_c.put(key, key, None);
+                lfu_c.put(key, key, 1);
                 assert_eq!(lfu_c.capacity(), 1000);
                 assert_eq!(lfu_c.segment_count(), 8);
 
-                lfuda_c.put(key, key, None);
+                lfuda_c.put(key, key, 1);
                 assert_eq!(lfuda_c.capacity(), 1000);
                 assert_eq!(lfuda_c.segment_count(), 4);
 
-                slru_c.put(key, key, None);
+                slru_c.put(key, key, 1);
                 assert_eq!(slru_c.capacity(), 1000);
                 assert_eq!(slru_c.segment_count(), 8);
 
-                gdsf_c.put(key, key, Some(1));
+                gdsf_c.put(key, key, 1);
                 assert_eq!(gdsf_c.capacity(), 1000);
                 assert_eq!(gdsf_c.segment_count(), 4);
             }
@@ -3102,19 +3102,19 @@ fn test_concurrent_all_caches_algorithm_name() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
 
                 // Do operations while checking algorithm names
-                lru_c.put(key, key, None);
+                lru_c.put(key, key, 1);
                 assert_eq!(lru_c.algorithm_name(), "ConcurrentLRU");
 
-                lfu_c.put(key, key, None);
+                lfu_c.put(key, key, 1);
                 assert_eq!(lfu_c.algorithm_name(), "ConcurrentLFU");
 
-                lfuda_c.put(key, key, None);
+                lfuda_c.put(key, key, 1);
                 assert_eq!(lfuda_c.algorithm_name(), "ConcurrentLFUDA");
 
-                slru_c.put(key, key, None);
+                slru_c.put(key, key, 1);
                 assert_eq!(slru_c.algorithm_name(), "ConcurrentSLRU");
 
-                gdsf_c.put(key, key, Some(1));
+                gdsf_c.put(key, key, 1);
                 assert_eq!(gdsf_c.algorithm_name(), "ConcurrentGDSF");
             }
         }));
@@ -3152,17 +3152,17 @@ fn test_concurrent_all_caches_metrics() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
 
                 // Perform operations and check metrics exist
-                lru_c.put(key, key, None);
+                lru_c.put(key, key, 1);
                 let _ = lru_c.get(&key);
                 let metrics = lru_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "LRU should track hits");
 
-                lfu_c.put(key, key, None);
+                lfu_c.put(key, key, 1);
                 let _ = lfu_c.get(&key);
                 let metrics = lfu_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "LFU should track hits");
 
-                lfuda_c.put(key, key, None);
+                lfuda_c.put(key, key, 1);
                 let _ = lfuda_c.get(&key);
                 let metrics = lfuda_c.metrics();
                 assert!(
@@ -3170,12 +3170,12 @@ fn test_concurrent_all_caches_metrics() {
                     "LFUDA should track hits"
                 );
 
-                slru_c.put(key, key, None);
+                slru_c.put(key, key, 1);
                 let _ = slru_c.get(&key);
                 let metrics = slru_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "SLRU should track hits");
 
-                gdsf_c.put(key, key, Some(1));
+                gdsf_c.put(key, key, 1);
                 let _ = gdsf_c.get(&key);
                 let metrics = gdsf_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "GDSF should track hits");

--- a/tests/concurrent_correctness_tests.rs
+++ b/tests/concurrent_correctness_tests.rs
@@ -190,7 +190,7 @@ fn test_concurrent_lru_basic_eviction() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Mixed operations simulating real-world usage
-                c.put(key, key * 10);
+                c.put(key, key * 10, None);
                 let _ = c.get(&key);
                 if i % 5 == 0 {
                     let _ = c.contains(&key);
@@ -224,7 +224,7 @@ fn test_concurrent_lru_access_prevents_eviction() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100);
+        cache.put(key, key * 100, None);
     }
 
     let mut handles = vec![];
@@ -242,7 +242,7 @@ fn test_concurrent_lru_access_prevents_eviction() {
 
                 // Also insert new cold keys that may get evicted
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
-                c.put(cold_key, cold_key);
+                c.put(cold_key, cold_key, None);
 
                 // Realistic operations mix
                 if i % 3 == 0 {
@@ -279,7 +279,7 @@ fn test_concurrent_lru_multi_segment_eviction() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Real-world pattern: put, then read multiple times
-                c.put(key, key * 10);
+                c.put(key, key * 10, None);
                 for _ in 0..3 {
                     let _ = c.get(&key);
                 }
@@ -315,7 +315,7 @@ fn test_concurrent_lru_concurrent_writes_maintain_capacity() {
         handles.push(thread::spawn(move || {
             for i in 0..100 {
                 let key = t * 1000 + i;
-                cache.put(key, key);
+                cache.put(key, key, None);
             }
         }));
     }
@@ -345,7 +345,7 @@ fn test_concurrent_lfu_frequency_based_eviction() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100);
+        cache.put(key, key * 100, None);
     }
 
     let mut handles = vec![];
@@ -365,7 +365,7 @@ fn test_concurrent_lfu_frequency_based_eviction() {
 
                 // Insert cold keys that should get evicted due to low frequency
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
-                c.put(cold_key, cold_key);
+                c.put(cold_key, cold_key, None);
 
                 // Realistic mix: peek doesn't update frequency
                 if i % 5 == 0 {
@@ -393,9 +393,9 @@ fn test_concurrent_lfu_frequency_accumulation() {
         Arc::new(ConcurrentLfuCache::init(lfu_config(6, 2), None));
 
     // Insert items
-    cache.put("hot".to_string(), 1);
-    cache.put("warm".to_string(), 2);
-    cache.put("cold".to_string(), 3);
+    cache.put("hot".to_string(), 1, None);
+    cache.put("warm".to_string(), 2, None);
+    cache.put("cold".to_string(), 3, None);
 
     let cache_clone = Arc::clone(&cache);
 
@@ -416,10 +416,10 @@ fn test_concurrent_lfu_frequency_accumulation() {
 
     // "hot" should have very high frequency now
     // Fill cache to trigger eviction
-    cache_clone.put("new1".to_string(), 4);
-    cache_clone.put("new2".to_string(), 5);
-    cache_clone.put("new3".to_string(), 6);
-    cache_clone.put("new4".to_string(), 7);
+    cache_clone.put("new1".to_string(), 4, None);
+    cache_clone.put("new2".to_string(), 5, None);
+    cache_clone.put("new3".to_string(), 6, None);
+    cache_clone.put("new4".to_string(), 7, None);
 
     // "hot" should survive due to high frequency
     assert!(
@@ -442,7 +442,7 @@ fn test_concurrent_lfu_multi_segment_correctness() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Put and then access to build frequency
-                c.put(key, key * 10);
+                c.put(key, key * 10, None);
 
                 // Access some keys more to increase frequency
                 if key % 10 < 3 {
@@ -488,7 +488,7 @@ fn test_concurrent_lfuda_priority_eviction() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100);
+        cache.put(key, key * 100, None);
     }
 
     let mut handles = vec![];
@@ -508,7 +508,7 @@ fn test_concurrent_lfuda_priority_eviction() {
 
                 // Insert cold keys that may get evicted
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
-                c.put(cold_key, cold_key);
+                c.put(cold_key, cold_key, None);
 
                 // Mix in other operations
                 if i % 5 == 0 {
@@ -545,7 +545,7 @@ fn test_concurrent_lfuda_aging_mechanism() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 10);
+                c.put(key, key * 10, None);
 
                 // Access some keys to build priority
                 if i % 3 == 0 {
@@ -591,7 +591,7 @@ fn test_concurrent_slru_segment_behavior() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Items start in probationary
-                c.put(key, key * 10);
+                c.put(key, key * 10, None);
 
                 // Access multiple times to promote to protected
                 if i % 3 == 0 {
@@ -629,7 +629,7 @@ fn test_concurrent_slru_promotion_under_concurrency() {
 
     // Pre-populate with items
     for i in 0..20 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
 
     let mut handles = vec![];
@@ -640,7 +640,7 @@ fn test_concurrent_slru_promotion_under_concurrency() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 10);
+                c.put(key, key * 10, None);
 
                 // Access repeatedly to promote to protected
                 for _ in 0..4 {
@@ -688,7 +688,7 @@ fn test_concurrent_gdsf_size_aware_eviction() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Vary sizes: small objects should have higher priority
                 let size = if i % 5 == 0 { 100 } else { 1 }; // Large vs small
-                c.put(key, key * 10, size);
+                c.put(key, key * 10, Some(size));
 
                 // Access to build frequency
                 if i % 3 == 0 {
@@ -726,7 +726,7 @@ fn test_concurrent_gdsf_frequency_matters() {
 
     // Insert hot keys first
     for &key in &hot_keys {
-        cache.put(key, key * 100, 1);
+        cache.put(key, key * 100, Some(1));
     }
 
     let mut handles = vec![];
@@ -747,7 +747,7 @@ fn test_concurrent_gdsf_frequency_matters() {
                 // Insert cold keys
                 let cold_key = 1000 + (t * OPS_PER_THREAD + i) as i32;
                 let size = ((i % 10) + 1) as u64;
-                c.put(cold_key, cold_key, size);
+                c.put(cold_key, cold_key, Some(size));
 
                 // Mixed operations
                 if i % 5 == 0 {
@@ -785,7 +785,7 @@ fn test_concurrent_gdsf_concurrent_size_tracking() {
             for i in 0..5 {
                 let key = t * 10 + i;
                 let size = ((i + 1) * 10) as u64;
-                c.put(key, key, size);
+                c.put(key, key, Some(size));
             }
         }));
     }
@@ -824,7 +824,7 @@ fn test_capacity_never_exceeded_lru() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key);
+                c.put(key, key, None);
                 wc.fetch_add(1, Ordering::Relaxed);
 
                 // Check invariant during operation
@@ -857,7 +857,7 @@ fn test_capacity_never_exceeded_lfu() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key);
+                c.put(key, key, None);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -885,7 +885,7 @@ fn test_capacity_never_exceeded_slru() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key);
+                c.put(key, key, None);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -911,7 +911,7 @@ fn test_capacity_never_exceeded_lfuda() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key);
+                c.put(key, key, None);
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -937,7 +937,7 @@ fn test_capacity_never_exceeded_gdsf() {
         handles.push(thread::spawn(move || {
             for i in 0..500 {
                 let key = t * 1000 + i;
-                c.put(key, key, 1);
+                c.put(key, key, Some(1));
                 assert!(c.len() <= capacity, "Capacity exceeded!");
             }
         }));
@@ -961,7 +961,7 @@ fn test_get_returns_correct_value() {
 
     // Insert known values
     for i in 0..50 {
-        cache.put(i, i * 100);
+        cache.put(i, i * 100, None);
     }
 
     let errors = Arc::new(AtomicUsize::new(0));
@@ -994,7 +994,7 @@ fn test_update_is_atomic() {
     let cache: Arc<ConcurrentLruCache<i32, i32>> =
         Arc::new(ConcurrentLruCache::init(lru_config(10, 2), None));
 
-    cache.put(1, 0);
+    cache.put(1, 0, None);
 
     let mut handles = vec![];
 
@@ -1003,7 +1003,7 @@ fn test_update_is_atomic() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for _ in 0..100 {
-                c.put(1, t);
+                c.put(1, t, None);
             }
         }));
     }
@@ -1030,7 +1030,7 @@ fn test_remove_consistency() {
 
     // Insert items
     for i in 0..50 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     // Verify all items were inserted before attempting removes
@@ -1082,7 +1082,7 @@ fn test_mixed_operations_lru() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..200 {
-                c.put(t * 1000 + i, i);
+                c.put(t * 1000 + i, i, None);
             }
         }));
     }
@@ -1126,7 +1126,7 @@ fn test_mixed_operations_lfu() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..200 {
-                c.put(t * 1000 + i, i);
+                c.put(t * 1000 + i, i, None);
                 let _ = c.get(&(t * 1000 + i));
             }
         }));
@@ -1150,7 +1150,7 @@ fn test_mixed_operations_slru() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..200 {
-                c.put(t * 1000 + i, i);
+                c.put(t * 1000 + i, i, None);
                 // Access multiple times to trigger promotion
                 for _ in 0..3 {
                     let _ = c.get(&(t * 1000 + i));
@@ -1178,7 +1178,7 @@ fn test_mixed_operations_gdsf() {
         handles.push(thread::spawn(move || {
             for i in 0..200 {
                 let size = (i % 10 + 1) as u64;
-                c.put(t * 1000 + i, i, size);
+                c.put(t * 1000 + i, i, Some(size));
                 let _ = c.get(&(t * 1000 + i));
             }
         }));
@@ -1210,7 +1210,7 @@ fn test_clear_during_operations() {
         handles.push(thread::spawn(move || {
             let mut i = 0;
             while sf.load(Ordering::Relaxed) == 0 {
-                c.put(t * 10000 + i, i);
+                c.put(t * 10000 + i, i, None);
                 i += 1;
             }
         }));
@@ -1254,7 +1254,7 @@ fn test_size_tracking_concurrent_lru() {
         handles.push(thread::spawn(move || {
             for i in 0..25 {
                 let key = t * 100 + i;
-                c.put_with_size(key, format!("value_{}", key), 10);
+                c.put(key, format!("value_{}", key), Some(10));
             }
         }));
     }
@@ -1286,7 +1286,7 @@ fn test_size_tracking_concurrent_lfu() {
         handles.push(thread::spawn(move || {
             for i in 0..25 {
                 let key = t * 100 + i;
-                c.put_with_size(key, format!("value_{}", key), 10);
+                c.put(key, format!("value_{}", key), Some(10));
             }
         }));
     }
@@ -1343,7 +1343,7 @@ fn test_concurrent_single_key() {
         let gc = Arc::clone(&get_count);
         handles.push(thread::spawn(move || {
             for i in 0..100 {
-                c.put(1, i);
+                c.put(1, i, None);
                 pc.fetch_add(1, Ordering::Relaxed);
                 if c.get(&1).is_some() {
                     gc.fetch_add(1, Ordering::Relaxed);
@@ -1373,7 +1373,7 @@ fn test_concurrent_capacity_one() {
         let c = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..100 {
-                c.put(t * 100 + i, i);
+                c.put(t * 100 + i, i, None);
             }
         }));
     }
@@ -1393,7 +1393,7 @@ fn test_contains_key_consistency() {
 
     // Insert known keys
     for i in 0..30 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     let mut handles = vec![];
@@ -1449,11 +1449,11 @@ fn test_all_concurrent_caches_len_consistency() {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Mixed operations on all cache types
-                lru_c.put(key, key);
-                lfu_c.put(key, key);
-                lfuda_c.put(key, key);
-                slru_c.put(key, key);
-                gdsf_c.put(key, key, 1);
+                lru_c.put(key, key, None);
+                lfu_c.put(key, key, None);
+                lfuda_c.put(key, key, None);
+                slru_c.put(key, key, None);
+                gdsf_c.put(key, key, Some(1));
 
                 if i % 3 == 0 {
                     let _ = lru_c.get(&key);
@@ -1510,11 +1510,11 @@ fn test_all_concurrent_caches_clear() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                lru_c.put(key, key);
-                lfu_c.put(key, key);
-                lfuda_c.put(key, key);
-                slru_c.put(key, key);
-                gdsf_c.put(key, key, 1);
+                lru_c.put(key, key, None);
+                lfu_c.put(key, key, None);
+                lfuda_c.put(key, key, None);
+                slru_c.put(key, key, None);
+                gdsf_c.put(key, key, Some(1));
 
                 // Periodically clear all caches (simulates cache reset)
                 if i % 100 == 0 {
@@ -1574,7 +1574,7 @@ fn test_concurrent_lru_size_based_eviction() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), object_size);
+                c.put(key, format!("value_{}", key), Some(object_size));
 
                 // Mixed operations
                 if i % 3 == 0 {
@@ -1627,7 +1627,7 @@ fn test_concurrent_lfu_size_based_eviction() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), object_size);
+                c.put(key, format!("value_{}", key), Some(object_size));
 
                 // Build frequency on some keys
                 if i % 5 == 0 {
@@ -1680,7 +1680,7 @@ fn test_concurrent_lfuda_size_based_eviction() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), object_size);
+                c.put(key, format!("value_{}", key), Some(object_size));
 
                 // Build priority on some keys
                 if i % 4 == 0 {
@@ -1737,7 +1737,7 @@ fn test_concurrent_gdsf_size_based_eviction() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Vary sizes to test GDSF's size-aware eviction
                 let size = ((i % 5) + 1) as u64 * 256; // 256 to 1280 bytes
-                c.put(key, format!("value_{}", key), size);
+                c.put(key, format!("value_{}", key), Some(size));
 
                 // Build frequency on some keys
                 if i % 3 == 0 {
@@ -1791,7 +1791,7 @@ fn test_concurrent_lru_per_segment_size_limit() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
                 // Use varying large object sizes
                 let size = ((i % 4) + 1) as u64 * 2048; // 2KB to 8KB
-                c.put_with_size(key, format!("large_value_{}", key), size);
+                c.put(key, format!("large_value_{}", key), Some(size));
 
                 // Verify size limits during concurrent access
                 let current = c.current_size();
@@ -1847,7 +1847,7 @@ fn test_concurrent_size_tracking_accuracy() {
             std::thread::spawn(move || {
                 for i in 0..25 {
                     let key = t * 25 + i;
-                    cache.put_with_size(key, format!("value_{}", key), item_size);
+                    cache.put(key, format!("value_{}", key), Some(item_size));
                 }
             })
         })
@@ -1889,7 +1889,7 @@ fn test_concurrent_size_tracking_on_remove() {
 
     // Pre-populate cache
     for i in 0..100 {
-        cache.put_with_size(i, format!("value_{}", i), item_size);
+        cache.put(i, format!("value_{}", i), Some(item_size));
     }
 
     let size_before = cache.current_size();
@@ -1910,7 +1910,7 @@ fn test_concurrent_size_tracking_on_remove() {
                 }
 
                 // Add new keys
-                c.put_with_size(key + 1000, format!("new_value_{}", key), item_size);
+                c.put(key + 1000, format!("new_value_{}", key), Some(item_size));
 
                 // Mixed operations
                 if i % 3 == 0 {
@@ -1975,7 +1975,7 @@ fn test_concurrent_lru_with_max_size() {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
                 let data = vec![0u8; 100];
-                c.put_with_size(key.clone(), data, 100);
+                c.put(key.clone(), data, Some(100));
 
                 if i % 3 == 0 {
                     let _ = c.get(&key);
@@ -2014,7 +2014,7 @@ fn test_concurrent_lru_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), 100);
+                c.put(key, format!("value_{}", key), Some(100));
 
                 // Periodically clear to test clear under concurrency
                 if i % 50 == 0 {
@@ -2063,7 +2063,7 @@ fn test_concurrent_lfu_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put_with_size(key.clone(), vec![1, 2, 3], 100);
+                c.put(key.clone(), vec![1, 2, 3], Some(100));
                 if i % 3 == 0 {
                     let _ = c.get(&key);
                 }
@@ -2093,7 +2093,7 @@ fn test_concurrent_lfu_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), 100);
+                c.put(key, format!("value_{}", key), Some(100));
                 if i % 50 == 0 {
                     c.clear();
                 }
@@ -2139,7 +2139,7 @@ fn test_concurrent_lfuda_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put_with_size(key.clone(), vec![1, 2, 3], 100);
+                c.put(key.clone(), vec![1, 2, 3], Some(100));
                 if i % 3 == 0 {
                     let _ = c.get(&key);
                 }
@@ -2169,7 +2169,7 @@ fn test_concurrent_lfuda_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), 100);
+                c.put(key, format!("value_{}", key), Some(100));
                 if i % 50 == 0 {
                     c.clear();
                 }
@@ -2215,7 +2215,7 @@ fn test_concurrent_gdsf_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put(key.clone(), vec![1, 2, 3], 100);
+                c.put(key.clone(), vec![1, 2, 3], Some(100));
                 if i % 3 == 0 {
                     let _ = c.get(&key);
                 }
@@ -2245,7 +2245,7 @@ fn test_concurrent_gdsf_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, format!("value_{}", key), 100);
+                c.put(key, format!("value_{}", key), Some(100));
                 if i % 50 == 0 {
                     c.clear();
                 }
@@ -2291,7 +2291,7 @@ fn test_concurrent_slru_with_max_size() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = format!("key_{}_{}", t, i);
-                c.put_with_size(key.clone(), vec![1, 2, 3], 100);
+                c.put(key.clone(), vec![1, 2, 3], Some(100));
                 // Access multiple times to test promotion
                 for _ in 0..3 {
                     let _ = c.get(&key);
@@ -2322,7 +2322,7 @@ fn test_concurrent_slru_with_limits() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put_with_size(key, format!("value_{}", key), 100);
+                c.put(key, format!("value_{}", key), Some(100));
                 // Access to trigger promotion to protected
                 for _ in 0..3 {
                     let _ = c.get(&key);
@@ -2354,7 +2354,7 @@ fn test_concurrent_clear_during_operations() {
 
     // Pre-fill
     for i in 0..100 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
     assert_eq!(cache.len(), 100);
 
@@ -2372,7 +2372,7 @@ fn test_concurrent_clear_during_operations() {
 
     // Insert while clear is happening
     for i in 100..200 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     handle.join().unwrap();
@@ -2403,7 +2403,7 @@ fn test_concurrent_lru_record_miss() {
 
                 // Also do actual cache operations
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key);
+                c.put(key, key, None);
                 let _ = c.get(&key);
             }
         }));
@@ -2439,7 +2439,7 @@ fn test_concurrent_lru_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2);
+                c.put(key, key * 2, None);
                 // Use get_with to transform value - may be None if evicted
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2470,7 +2470,7 @@ fn test_concurrent_lfu_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2);
+                c.put(key, key * 2, None);
                 // Use get_with to transform value - may be None if evicted
                 let doubled = c.get_with(&key, |v| v * 2);
                 // Value could be evicted by another thread, so it may be None
@@ -2502,7 +2502,7 @@ fn test_concurrent_lfuda_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2);
+                c.put(key, key * 2, None);
                 // Value could be evicted by another thread, so it may be None
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2532,7 +2532,7 @@ fn test_concurrent_slru_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2);
+                c.put(key, key * 2, None);
                 // Value could be evicted by another thread
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2562,7 +2562,7 @@ fn test_concurrent_gdsf_get_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key * 2, 1);
+                c.put(key, key * 2, Some(1));
                 // Value could be evicted by another thread
                 let doubled = c.get_with(&key, |v| v * 2);
                 if let Some(val) = doubled {
@@ -2596,7 +2596,7 @@ fn test_concurrent_lru_get_mut_with() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key);
+                c.put(key, key, None);
                 // Use get_mut_with to mutate value in-place - may be None if evicted
                 let old_val = c.get_mut_with(&key, |v| {
                     let old = *v;
@@ -2652,35 +2652,35 @@ fn test_concurrent_all_caches_contains() {
                 // Note: We can't assert contains() results in concurrent tests because
                 // another thread may evict entries at any time between put and contains
                 let _ = lru_c.contains(&key);
-                lru_c.put(key, key);
+                lru_c.put(key, key, None);
                 let _ = lru_c.contains(&key); // May be false if evicted by another thread
                 if i % 10 == 0 {
                     lru_c.remove(&key);
                 }
 
                 // LFU
-                lfu_c.put(key, key);
+                lfu_c.put(key, key, None);
                 let _ = lfu_c.contains(&key);
                 if i % 10 == 0 {
                     lfu_c.remove(&key);
                 }
 
                 // LFUDA
-                lfuda_c.put(key, key);
+                lfuda_c.put(key, key, None);
                 let _ = lfuda_c.contains(&key);
                 if i % 10 == 0 {
                     lfuda_c.remove(&key);
                 }
 
                 // SLRU
-                slru_c.put(key, key);
+                slru_c.put(key, key, None);
                 let _ = slru_c.contains(&key);
                 if i % 10 == 0 {
                     slru_c.remove(&key);
                 }
 
                 // GDSF
-                gdsf_c.put(key, key, 1);
+                gdsf_c.put(key, key, Some(1));
                 let _ = gdsf_c.contains(&key);
                 if i % 10 == 0 {
                     gdsf_c.remove(&key);
@@ -2710,7 +2710,7 @@ fn test_concurrent_lru_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key);
+                c.put(key, key, None);
                 // peek returns cloned value - may be None if evicted
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2741,7 +2741,7 @@ fn test_concurrent_lfu_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key);
+                c.put(key, key, None);
                 // Value could be evicted by another thread
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2771,7 +2771,7 @@ fn test_concurrent_lfuda_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key);
+                c.put(key, key, None);
                 // Value could be evicted by another thread
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2801,7 +2801,7 @@ fn test_concurrent_slru_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key);
+                c.put(key, key, None);
                 // Value could be evicted by another thread, so it may be None
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2831,7 +2831,7 @@ fn test_concurrent_gdsf_peek() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = (t * OPS_PER_THREAD + i) as i32;
-                c.put(key, key, 1);
+                c.put(key, key, Some(1));
                 // Value could be evicted by another thread
                 let peeked = c.peek(&key);
                 if let Some(val) = peeked {
@@ -2860,7 +2860,7 @@ fn test_concurrent_lru_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     let mut handles = vec![];
@@ -2874,7 +2874,7 @@ fn test_concurrent_lru_pop() {
                 // Popped might be Some or None depending on cache state
                 if let Some((k, _v)) = popped {
                     // Put something back
-                    c.put(k + 10000, k);
+                    c.put(k + 10000, k, None);
                 }
             }
         }));
@@ -2895,7 +2895,7 @@ fn test_concurrent_lfu_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     let mut handles = vec![];
@@ -2906,7 +2906,7 @@ fn test_concurrent_lfu_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k);
+                    c.put(k + 10000, k, None);
                 }
             }
         }));
@@ -2926,7 +2926,7 @@ fn test_concurrent_lfuda_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     let mut handles = vec![];
@@ -2937,7 +2937,7 @@ fn test_concurrent_lfuda_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k);
+                    c.put(k + 10000, k, None);
                 }
             }
         }));
@@ -2957,7 +2957,7 @@ fn test_concurrent_slru_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     let mut handles = vec![];
@@ -2968,7 +2968,7 @@ fn test_concurrent_slru_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k);
+                    c.put(k + 10000, k, None);
                 }
             }
         }));
@@ -2988,7 +2988,7 @@ fn test_concurrent_gdsf_pop() {
 
     // Pre-fill cache
     for i in 0..500 {
-        cache.put(i, i, 1);
+        cache.put(i, i, Some(1));
     }
 
     let mut handles = vec![];
@@ -2999,7 +2999,7 @@ fn test_concurrent_gdsf_pop() {
             for _ in 0..OPS_PER_THREAD {
                 let popped = c.pop();
                 if let Some((k, _v)) = popped {
-                    c.put(k + 10000, k, 1);
+                    c.put(k + 10000, k, Some(1));
                 }
             }
         }));
@@ -3043,23 +3043,23 @@ fn test_concurrent_all_caches_capacity_and_segments() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
 
                 // Perform operations while checking capacity/segments
-                lru_c.put(key, key);
+                lru_c.put(key, key, None);
                 assert_eq!(lru_c.capacity(), 1000);
                 assert_eq!(lru_c.segment_count(), 4);
 
-                lfu_c.put(key, key);
+                lfu_c.put(key, key, None);
                 assert_eq!(lfu_c.capacity(), 1000);
                 assert_eq!(lfu_c.segment_count(), 8);
 
-                lfuda_c.put(key, key);
+                lfuda_c.put(key, key, None);
                 assert_eq!(lfuda_c.capacity(), 1000);
                 assert_eq!(lfuda_c.segment_count(), 4);
 
-                slru_c.put(key, key);
+                slru_c.put(key, key, None);
                 assert_eq!(slru_c.capacity(), 1000);
                 assert_eq!(slru_c.segment_count(), 8);
 
-                gdsf_c.put(key, key, 1);
+                gdsf_c.put(key, key, Some(1));
                 assert_eq!(gdsf_c.capacity(), 1000);
                 assert_eq!(gdsf_c.segment_count(), 4);
             }
@@ -3102,19 +3102,19 @@ fn test_concurrent_all_caches_algorithm_name() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
 
                 // Do operations while checking algorithm names
-                lru_c.put(key, key);
+                lru_c.put(key, key, None);
                 assert_eq!(lru_c.algorithm_name(), "ConcurrentLRU");
 
-                lfu_c.put(key, key);
+                lfu_c.put(key, key, None);
                 assert_eq!(lfu_c.algorithm_name(), "ConcurrentLFU");
 
-                lfuda_c.put(key, key);
+                lfuda_c.put(key, key, None);
                 assert_eq!(lfuda_c.algorithm_name(), "ConcurrentLFUDA");
 
-                slru_c.put(key, key);
+                slru_c.put(key, key, None);
                 assert_eq!(slru_c.algorithm_name(), "ConcurrentSLRU");
 
-                gdsf_c.put(key, key, 1);
+                gdsf_c.put(key, key, Some(1));
                 assert_eq!(gdsf_c.algorithm_name(), "ConcurrentGDSF");
             }
         }));
@@ -3152,17 +3152,17 @@ fn test_concurrent_all_caches_metrics() {
                 let key = (t * OPS_PER_THREAD + i) as i32;
 
                 // Perform operations and check metrics exist
-                lru_c.put(key, key);
+                lru_c.put(key, key, None);
                 let _ = lru_c.get(&key);
                 let metrics = lru_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "LRU should track hits");
 
-                lfu_c.put(key, key);
+                lfu_c.put(key, key, None);
                 let _ = lfu_c.get(&key);
                 let metrics = lfu_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "LFU should track hits");
 
-                lfuda_c.put(key, key);
+                lfuda_c.put(key, key, None);
                 let _ = lfuda_c.get(&key);
                 let metrics = lfuda_c.metrics();
                 assert!(
@@ -3170,12 +3170,12 @@ fn test_concurrent_all_caches_metrics() {
                     "LFUDA should track hits"
                 );
 
-                slru_c.put(key, key);
+                slru_c.put(key, key, None);
                 let _ = slru_c.get(&key);
                 let metrics = slru_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "SLRU should track hits");
 
-                gdsf_c.put(key, key, 1);
+                gdsf_c.put(key, key, Some(1));
                 let _ = gdsf_c.get(&key);
                 let metrics = gdsf_c.metrics();
                 assert!(metrics.contains_key("cache_hits"), "GDSF should track hits");

--- a/tests/concurrent_stress_tests.rs
+++ b/tests/concurrent_stress_tests.rs
@@ -87,7 +87,7 @@ fn stress_lru_high_contention() {
             for i in 0..OPS_PER_THREAD {
                 let key = i % 10; // Only 10 keys for high contention
                 if t % 2 == 0 {
-                    cache.put(key, t * OPS_PER_THREAD + i, None);
+                    cache.put(key, t * OPS_PER_THREAD + i, 1);
                 } else {
                     let _ = cache.get(&key);
                 }
@@ -115,7 +115,7 @@ fn stress_segment_counts() {
             let cache = Arc::clone(&cache);
             handles.push(thread::spawn(move || {
                 for i in 0..1000 {
-                    cache.put(t * 1000 + i, i, None);
+                    cache.put(t * 1000 + i, i, 1);
                     let _ = cache.get(&(t * 1000 + i));
                 }
             }));
@@ -165,7 +165,7 @@ fn stress_single_item_cache() {
         let cache = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..1000 {
-                cache.put(t, i, None); // Each thread uses different key
+                cache.put(t, i, 1); // Each thread uses different key
                 let _ = cache.get(&t);
             }
         }));
@@ -191,7 +191,7 @@ fn stress_capacity_limits() {
         let cache = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
-                cache.put(t * OPS_PER_THREAD + i, i, None);
+                cache.put(t * OPS_PER_THREAD + i, i, 1);
             }
         }));
     }
@@ -212,7 +212,7 @@ fn stress_concurrent_removes() {
 
     // Pre-populate
     for i in 0..1000 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     let removed_count = Arc::new(AtomicUsize::new(0));
@@ -256,7 +256,7 @@ fn stress_concurrent_clear() {
         let cache = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..1000 {
-                cache.put(t * 1000 + i, i, None);
+                cache.put(t * 1000 + i, i, 1);
                 if i % 100 == 0 {
                     cache.clear();
                 }
@@ -284,7 +284,7 @@ fn stress_slru() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
-                cache.put(key, i, None);
+                cache.put(key, i, 1);
                 // Access multiple times to promote to protected segment
                 for _ in 0..3 {
                     let _ = cache.get(&key);
@@ -312,7 +312,7 @@ fn stress_lfu() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
-                cache.put(key, i, None);
+                cache.put(key, i, 1);
                 // Access some keys more frequently
                 if i % 10 == 0 {
                     for _ in 0..5 {
@@ -342,7 +342,7 @@ fn stress_lfuda() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
-                cache.put(key, i, None);
+                cache.put(key, i, 1);
                 let _ = cache.get(&key);
             }
         }));
@@ -368,7 +368,7 @@ fn stress_gdsf() {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
                 let size = ((i % 10) + 1) as u64;
-                cache.put(key, i, Some(size));
+                cache.put(key, i, size);
                 let _ = cache.get(&key);
             }
         }));
@@ -398,7 +398,7 @@ fn stress_mixed_all_caches() {
                 let value = format!("value_{}", i);
                 match i % 4 {
                     0 => {
-                        cache.put(key, value, None);
+                        cache.put(key, value, 1);
                     }
                     1 => {
                         let _ = cache.get(&key);
@@ -429,7 +429,7 @@ fn stress_get_with() {
 
     // Pre-populate with vectors
     for i in 0..100 {
-        cache.put(i, vec![i; 10], None);
+        cache.put(i, vec![i; 10], 1);
     }
 
     let sum = Arc::new(AtomicUsize::new(0));

--- a/tests/concurrent_stress_tests.rs
+++ b/tests/concurrent_stress_tests.rs
@@ -87,7 +87,7 @@ fn stress_lru_high_contention() {
             for i in 0..OPS_PER_THREAD {
                 let key = i % 10; // Only 10 keys for high contention
                 if t % 2 == 0 {
-                    cache.put(key, t * OPS_PER_THREAD + i);
+                    cache.put(key, t * OPS_PER_THREAD + i, None);
                 } else {
                     let _ = cache.get(&key);
                 }
@@ -115,7 +115,7 @@ fn stress_segment_counts() {
             let cache = Arc::clone(&cache);
             handles.push(thread::spawn(move || {
                 for i in 0..1000 {
-                    cache.put(t * 1000 + i, i);
+                    cache.put(t * 1000 + i, i, None);
                     let _ = cache.get(&(t * 1000 + i));
                 }
             }));
@@ -165,7 +165,7 @@ fn stress_single_item_cache() {
         let cache = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..1000 {
-                cache.put(t, i); // Each thread uses different key
+                cache.put(t, i, None); // Each thread uses different key
                 let _ = cache.get(&t);
             }
         }));
@@ -191,7 +191,7 @@ fn stress_capacity_limits() {
         let cache = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
-                cache.put(t * OPS_PER_THREAD + i, i);
+                cache.put(t * OPS_PER_THREAD + i, i, None);
             }
         }));
     }
@@ -212,7 +212,7 @@ fn stress_concurrent_removes() {
 
     // Pre-populate
     for i in 0..1000 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     let removed_count = Arc::new(AtomicUsize::new(0));
@@ -256,7 +256,7 @@ fn stress_concurrent_clear() {
         let cache = Arc::clone(&cache);
         handles.push(thread::spawn(move || {
             for i in 0..1000 {
-                cache.put(t * 1000 + i, i);
+                cache.put(t * 1000 + i, i, None);
                 if i % 100 == 0 {
                     cache.clear();
                 }
@@ -284,7 +284,7 @@ fn stress_slru() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
-                cache.put(key, i);
+                cache.put(key, i, None);
                 // Access multiple times to promote to protected segment
                 for _ in 0..3 {
                     let _ = cache.get(&key);
@@ -312,7 +312,7 @@ fn stress_lfu() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
-                cache.put(key, i);
+                cache.put(key, i, None);
                 // Access some keys more frequently
                 if i % 10 == 0 {
                     for _ in 0..5 {
@@ -342,7 +342,7 @@ fn stress_lfuda() {
         handles.push(thread::spawn(move || {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
-                cache.put(key, i);
+                cache.put(key, i, None);
                 let _ = cache.get(&key);
             }
         }));
@@ -368,7 +368,7 @@ fn stress_gdsf() {
             for i in 0..OPS_PER_THREAD {
                 let key = t * OPS_PER_THREAD + i;
                 let size = ((i % 10) + 1) as u64;
-                cache.put(key, i, size);
+                cache.put(key, i, Some(size));
                 let _ = cache.get(&key);
             }
         }));
@@ -398,7 +398,7 @@ fn stress_mixed_all_caches() {
                 let value = format!("value_{}", i);
                 match i % 4 {
                     0 => {
-                        cache.put(key, value);
+                        cache.put(key, value, None);
                     }
                     1 => {
                         let _ = cache.get(&key);
@@ -429,7 +429,7 @@ fn stress_get_with() {
 
     // Pre-populate with vectors
     for i in 0..100 {
-        cache.put(i, vec![i; 10]);
+        cache.put(i, vec![i; 10], None);
     }
 
     let sum = Arc::new(AtomicUsize::new(0));

--- a/tests/correctness_tests.rs
+++ b/tests/correctness_tests.rs
@@ -146,9 +146,9 @@ fn test_lru_evicts_least_recently_used() {
     let mut cache = make_lru(3);
 
     // Fill cache: order of insertion determines initial LRU order
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
     // LRU order: 1 (LRU) -> 2 -> 3 (MRU)
 
     // Verify all present before any eviction
@@ -158,7 +158,7 @@ fn test_lru_evicts_least_recently_used() {
     // After gets: LRU order is now 1 -> 2 -> 3 (order of access)
 
     // Insert new key - should evict key 1 (LRU)
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     // VALIDATE EVICTION: Key 1 should be evicted
     assert!(
@@ -171,7 +171,7 @@ fn test_lru_evicts_least_recently_used() {
     // After gets: LRU order is 2 -> 3 -> 4
 
     // Insert another - should evict key 2 (now LRU)
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // VALIDATE EVICTION: Key 2 should be evicted
     assert!(
@@ -189,26 +189,26 @@ fn test_lru_eviction_order_is_predictable() {
 
     // Fill cache with keys 0..4
     for i in 0..5 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
     // LRU order: 0 (LRU) -> 1 -> 2 -> 3 -> 4 (MRU)
 
     // Insert key 5 - should evict key 0
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
     assert!(
         cache.get(&0).is_none(),
         "First eviction: Key 0 should be evicted"
     );
 
     // Insert key 6 - should evict key 1
-    cache.put(6, 60, None);
+    cache.put(6, 60, 1);
     assert!(
         cache.get(&1).is_none(),
         "Second eviction: Key 1 should be evicted"
     );
 
     // Insert key 7 - should evict key 2
-    cache.put(7, 70, None);
+    cache.put(7, 70, 1);
     assert!(
         cache.get(&2).is_none(),
         "Third eviction: Key 2 should be evicted"
@@ -227,9 +227,9 @@ fn test_lru_get_updates_recency() {
     let mut cache = make_lru(3);
 
     // Fill cache
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
     // LRU order: 1 (LRU) -> 2 -> 3 (MRU)
 
     // Access key 1 to make it recently used
@@ -237,7 +237,7 @@ fn test_lru_get_updates_recency() {
     // LRU order: 2 (LRU) -> 3 -> 1 (MRU)
 
     // Insert new key - should evict key 2 (now LRU), NOT key 1
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     // VALIDATE: Key 2 evicted (not key 1 which was accessed)
     assert!(
@@ -266,9 +266,9 @@ fn test_lfu_evicts_least_frequently_used() {
     let mut cache = make_lfu(3);
 
     // Fill cache
-    cache.put(1, 10, None); // freq=1
-    cache.put(2, 20, None); // freq=1
-    cache.put(3, 30, None); // freq=1
+    cache.put(1, 10, 1); // freq=1
+    cache.put(2, 20, 1); // freq=1
+    cache.put(3, 30, 1); // freq=1
 
     // Access key 1 and 2 to increase their frequency
     cache.get(&1); // freq=2
@@ -278,7 +278,7 @@ fn test_lfu_evicts_least_frequently_used() {
     // Frequencies: key1=3, key2=2, key3=1 (lowest)
 
     // Insert new key - should evict key 3 (lowest frequency)
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     // VALIDATE EVICTION: Key 3 should be evicted (freq=1)
     assert!(
@@ -294,9 +294,9 @@ fn test_lfu_evicts_least_frequently_used() {
 fn test_lfu_frequency_accumulates() {
     let mut cache = make_lfu(3);
 
-    cache.put("hot", 1, None);
-    cache.put("warm", 2, None);
-    cache.put("cold", 3, None);
+    cache.put("hot", 1, 1);
+    cache.put("warm", 2, 1);
+    cache.put("cold", 3, 1);
 
     // Access "hot" many times (freq=11)
     for _ in 0..10 {
@@ -311,7 +311,7 @@ fn test_lfu_frequency_accumulates() {
     // Frequencies: hot=11, warm=4, cold=1 (lowest)
 
     // Insert new item - should evict "cold"
-    cache.put("new", 4, None);
+    cache.put("new", 4, 1);
 
     // VALIDATE EVICTION: "cold" should be evicted (freq=1)
     assert!(
@@ -328,12 +328,12 @@ fn test_lfu_same_frequency_uses_fifo() {
     let mut cache = make_lfu(3);
 
     // Insert 3 items - all have same frequency (1)
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Insert new item - should evict key 1 (first inserted among same frequency)
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     // VALIDATE EVICTION: Key 1 should be evicted (FIFO among same freq)
     assert!(
@@ -342,7 +342,7 @@ fn test_lfu_same_frequency_uses_fifo() {
     );
 
     // Insert another - should evict key 2 (next in FIFO order)
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // VALIDATE EVICTION: Key 2 should be evicted (FIFO)
     assert!(
@@ -366,9 +366,9 @@ fn test_lfuda_evicts_lowest_priority() {
     let mut cache = make_lfuda(3);
 
     // Fill cache
-    cache.put(1, 10, None); // priority = freq + age = 1 + 0 = 1
-    cache.put(2, 20, None); // priority = 1 + 0 = 1
-    cache.put(3, 30, None); // priority = 1 + 0 = 1
+    cache.put(1, 10, 1); // priority = freq + age = 1 + 0 = 1
+    cache.put(2, 20, 1); // priority = 1 + 0 = 1
+    cache.put(3, 30, 1); // priority = 1 + 0 = 1
 
     // Access key 1 and 2 to increase their priority
     cache.get(&1); // priority increases
@@ -378,7 +378,7 @@ fn test_lfuda_evicts_lowest_priority() {
     // Key 3 has lowest priority (only initial put, no gets)
 
     // Insert new key - should evict key 3
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     // VALIDATE EVICTION: Key 3 should be evicted (lowest priority)
     assert!(
@@ -398,9 +398,9 @@ fn test_lfuda_aging_helps_new_items() {
     let mut cache = make_lfuda(3);
 
     // Insert items
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Access all items to increase frequency
     for _ in 0..5 {
@@ -411,8 +411,8 @@ fn test_lfuda_aging_helps_new_items() {
 
     // Now evict and insert several times to increase global age
     // Each eviction increases the age
-    cache.put(4, 40, None); // evicts one item, age increases
-    cache.put(5, 50, None); // evicts another, age increases more
+    cache.put(4, 40, 1); // evicts one item, age increases
+    cache.put(5, 50, 1); // evicts another, age increases more
 
     // New items benefit from the elevated global age
     // The surviving items should be those with highest effective priority
@@ -424,10 +424,10 @@ fn test_lfuda_basic_eviction() {
     let mut cache = make_lfuda(4);
 
     // Fill cache
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // Access first two items more frequently
     for _ in 0..3 {
@@ -436,7 +436,7 @@ fn test_lfuda_basic_eviction() {
     }
 
     // Insert new item - should evict 3 or 4 (lowest frequency)
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // VALIDATE EVICTION: One of 3 or 4 should be evicted (both have freq=1)
     let key3_evicted = cache.get(&3).is_none();
@@ -467,10 +467,10 @@ fn test_slru_promotion_to_protected() {
     let mut cache = make_slru(4, 2);
 
     // Insert items - they start in probationary
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // Access key 1 to promote it to protected segment
     cache.get(&1);
@@ -484,7 +484,7 @@ fn test_slru_promotion_to_protected() {
     // Probationary LRU order: 3 (LRU) -> 4 (MRU)
 
     // Insert new item - should evict from probationary (LRU in probationary = 3)
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // VALIDATE EVICTION: Key 3 should be evicted from probationary
     assert!(
@@ -502,10 +502,10 @@ fn test_slru_probationary_evicted_first() {
     let mut cache = make_slru(4, 2);
 
     // Insert 4 items (all in probationary initially)
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // Promote keys 3 and 4 to protected by accessing them
     cache.get(&3);
@@ -517,7 +517,7 @@ fn test_slru_probationary_evicted_first() {
     // Probationary LRU order: 1 (LRU) -> 2 (MRU)
 
     // Insert new item - should evict key 1 (LRU in probationary)
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // VALIDATE EVICTION: Key 1 should be evicted (LRU in probationary)
     assert!(
@@ -540,10 +540,10 @@ fn test_slru_eviction_order_in_probationary() {
     let mut cache = make_slru(4, 1);
 
     // Insert 4 items
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // Promote only key 4 to protected
     cache.get(&4);
@@ -552,19 +552,19 @@ fn test_slru_eviction_order_in_probationary() {
     // Probationary: 1 (LRU) -> 2 -> 3 (MRU), Protected: 4
 
     // Insert new items and verify eviction order from probationary
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
     assert!(
         cache.get(&1).is_none(),
         "First eviction: Key 1 should be evicted"
     );
 
-    cache.put(6, 60, None);
+    cache.put(6, 60, 1);
     assert!(
         cache.get(&2).is_none(),
         "Second eviction: Key 2 should be evicted"
     );
 
-    cache.put(7, 70, None);
+    cache.put(7, 70, 1);
     assert!(
         cache.get(&3).is_none(),
         "Third eviction: Key 3 should be evicted"
@@ -589,9 +589,9 @@ fn test_gdsf_prefers_smaller_objects() {
     let mut cache = make_gdsf(3);
 
     // Insert items with different sizes, same frequency
-    cache.put(1, 10, Some(100)); // Large object (size=100)
-    cache.put(2, 20, Some(1)); // Small object (size=1)
-    cache.put(3, 30, Some(1)); // Small object (size=1)
+    cache.put(1, 10, 100); // Large object (size=100)
+    cache.put(2, 20, 1); // Small object (size=1)
+    cache.put(3, 30, 1); // Small object (size=1)
 
     // All have frequency 1, but priorities differ:
     // Key 1: priority = 1/100 = 0.01
@@ -599,7 +599,7 @@ fn test_gdsf_prefers_smaller_objects() {
     // Key 3: priority = 1/1 = 1.0
 
     // Insert new item - should evict key 1 (lowest priority due to size)
-    cache.put(4, 40, Some(1));
+    cache.put(4, 40, 1);
 
     // VALIDATE EVICTION: Key 1 (large object) should be evicted
     assert!(
@@ -621,9 +621,9 @@ fn test_gdsf_frequency_matters() {
     let mut cache = make_gdsf(3);
 
     // Insert items with same size
-    cache.put(1, 10, Some(OBJECT_SIZE));
-    cache.put(2, 20, Some(OBJECT_SIZE));
-    cache.put(3, 30, Some(OBJECT_SIZE));
+    cache.put(1, 10, OBJECT_SIZE);
+    cache.put(2, 20, OBJECT_SIZE);
+    cache.put(3, 30, OBJECT_SIZE);
 
     // Access key 1 many times to increase frequency
     for _ in 0..10 {
@@ -639,7 +639,7 @@ fn test_gdsf_frequency_matters() {
     // Priorities (freq/size): key1=11/1=11, key2=4/1=4, key3=1/1=1
 
     // Insert new item - should evict key 3 (lowest priority)
-    cache.put(4, 40, Some(OBJECT_SIZE));
+    cache.put(4, 40, OBJECT_SIZE);
 
     // VALIDATE EVICTION: Key 3 should be evicted (lowest frequency)
     assert!(
@@ -655,23 +655,23 @@ fn test_gdsf_size_frequency_tradeoff() {
     let mut cache = make_gdsf(3);
 
     // Large object with high frequency
-    cache.put(1, 10, Some(100)); // size=100
+    cache.put(1, 10, 100); // size=100
     for _ in 0..20 {
         cache.get(&1); // freq=21
     }
     // Priority = 21/100 = 0.21
 
     // Small object with low frequency
-    cache.put(2, 20, Some(1)); // size=1, freq=1
-                               // Priority = 1/1 = 1.0
+    cache.put(2, 20, 1); // size=1, freq=1
+                         // Priority = 1/1 = 1.0
 
     // Another small object
-    cache.put(3, 30, Some(1)); // size=1, freq=1
-                               // Priority = 1/1 = 1.0
+    cache.put(3, 30, 1); // size=1, freq=1
+                         // Priority = 1/1 = 1.0
 
     // Despite high frequency, the large object has lower priority (0.21 < 1.0)
     // Insert new item
-    cache.put(4, 40, Some(1));
+    cache.put(4, 40, 1);
 
     // VALIDATE EVICTION: Large object evicted despite high frequency
     assert!(
@@ -688,25 +688,25 @@ fn test_gdsf_eviction_order_by_priority() {
     let mut cache = make_gdsf(4);
 
     // Insert items with varying size to create predictable priorities
-    cache.put(1, 10, Some(10)); // size=10, priority = 1/10 = 0.1
-    cache.put(2, 20, Some(5)); // size=5,  priority = 1/5 = 0.2
-    cache.put(3, 30, Some(2)); // size=2,  priority = 1/2 = 0.5
-    cache.put(4, 40, Some(1)); // size=1,  priority = 1/1 = 1.0
+    cache.put(1, 10, 10); // size=10, priority = 1/10 = 0.1
+    cache.put(2, 20, 5); // size=5,  priority = 1/5 = 0.2
+    cache.put(3, 30, 2); // size=2,  priority = 1/2 = 0.5
+    cache.put(4, 40, 1); // size=1,  priority = 1/1 = 1.0
 
     // Insert new items and verify eviction order (lowest priority first)
-    cache.put(5, 50, Some(1));
+    cache.put(5, 50, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 evicted first (priority 0.1)"
     );
 
-    cache.put(6, 60, Some(1));
+    cache.put(6, 60, 1);
     assert!(
         cache.get(&2).is_none(),
         "Key 2 evicted second (priority 0.2)"
     );
 
-    cache.put(7, 70, Some(1));
+    cache.put(7, 70, 1);
     assert!(
         cache.get(&3).is_none(),
         "Key 3 evicted third (priority 0.5)"
@@ -729,35 +729,35 @@ fn test_all_caches_basic_operations() {
 
     // LRU
     let mut lru = make_lru(10);
-    lru.put("key", 42, None);
+    lru.put("key", 42, 1);
     assert_eq!(lru.get(&"key"), Some(&42));
     assert_eq!(lru.remove(&"key"), Some(42));
     assert_eq!(lru.get(&"key"), None);
 
     // LFU
     let mut lfu = make_lfu(10);
-    lfu.put("key", 42, None);
+    lfu.put("key", 42, 1);
     assert_eq!(lfu.get(&"key"), Some(&42));
     assert_eq!(lfu.remove(&"key"), Some(42));
     assert_eq!(lfu.get(&"key"), None);
 
     // LFUDA
     let mut lfuda = make_lfuda(10);
-    lfuda.put("key", 42, None);
+    lfuda.put("key", 42, 1);
     assert_eq!(lfuda.get(&"key"), Some(&42));
     assert_eq!(lfuda.remove(&"key"), Some(42));
     assert_eq!(lfuda.get(&"key"), None);
 
     // SLRU
     let mut slru = make_slru(10, 5);
-    slru.put("key", 42, None);
+    slru.put("key", 42, 1);
     assert_eq!(slru.get(&"key"), Some(&42));
     assert_eq!(slru.remove(&"key"), Some(42));
     assert_eq!(slru.get(&"key"), None);
 
     // GDSF - note: get() returns Option<V>, not Option<&V>
     let mut gdsf = make_gdsf(10);
-    gdsf.put("key", 42, Some(1));
+    gdsf.put("key", 42, 1);
     assert_eq!(gdsf.get(&"key"), Some(42));
     // GDSF doesn't have remove(), verify key exists then clear
     gdsf.clear();
@@ -769,35 +769,35 @@ fn test_all_caches_capacity_enforcement() {
     // LRU
     let mut lru = make_lru(3);
     for i in 0..10 {
-        lru.put(i, i, None);
+        lru.put(i, i, 1);
     }
     assert_eq!(lru.len(), 3, "LRU should enforce capacity");
 
     // LFU
     let mut lfu = make_lfu(3);
     for i in 0..10 {
-        lfu.put(i, i, None);
+        lfu.put(i, i, 1);
     }
     assert_eq!(lfu.len(), 3, "LFU should enforce capacity");
 
     // LFUDA
     let mut lfuda = make_lfuda(3);
     for i in 0..10 {
-        lfuda.put(i, i, None);
+        lfuda.put(i, i, 1);
     }
     assert_eq!(lfuda.len(), 3, "LFUDA should enforce capacity");
 
     // SLRU
     let mut slru = make_slru(3, 1);
     for i in 0..10 {
-        slru.put(i, i, None);
+        slru.put(i, i, 1);
     }
     assert_eq!(slru.len(), 3, "SLRU should enforce capacity");
 
     // GDSF
     let mut gdsf = make_gdsf(3);
     for i in 0..10 {
-        gdsf.put(i, i, Some(1));
+        gdsf.put(i, i, 1);
     }
     assert_eq!(gdsf.len(), 3, "GDSF should enforce capacity");
 }
@@ -806,41 +806,41 @@ fn test_all_caches_capacity_enforcement() {
 fn test_all_caches_update_existing_key() {
     // LRU - updating existing key should not change len
     let mut lru = make_lru(3);
-    lru.put(1, 10, None);
-    lru.put(2, 20, None);
-    lru.put(1, 100, None); // Update key 1
+    lru.put(1, 10, 1);
+    lru.put(2, 20, 1);
+    lru.put(1, 100, 1); // Update key 1
     assert_eq!(lru.len(), 2, "LRU: update should not increase len");
     assert_eq!(lru.get(&1), Some(&100), "LRU: value should be updated");
 
     // LFU
     let mut lfu = make_lfu(3);
-    lfu.put(1, 10, None);
-    lfu.put(2, 20, None);
-    lfu.put(1, 100, None);
+    lfu.put(1, 10, 1);
+    lfu.put(2, 20, 1);
+    lfu.put(1, 100, 1);
     assert_eq!(lfu.len(), 2, "LFU: update should not increase len");
     assert_eq!(lfu.get(&1), Some(&100), "LFU: value should be updated");
 
     // LFUDA
     let mut lfuda = make_lfuda(3);
-    lfuda.put(1, 10, None);
-    lfuda.put(2, 20, None);
-    lfuda.put(1, 100, None);
+    lfuda.put(1, 10, 1);
+    lfuda.put(2, 20, 1);
+    lfuda.put(1, 100, 1);
     assert_eq!(lfuda.len(), 2, "LFUDA: update should not increase len");
     assert_eq!(lfuda.get(&1), Some(&100), "LFUDA: value should be updated");
 
     // SLRU
     let mut slru = make_slru(3, 1);
-    slru.put(1, 10, None);
-    slru.put(2, 20, None);
-    slru.put(1, 100, None);
+    slru.put(1, 10, 1);
+    slru.put(2, 20, 1);
+    slru.put(1, 100, 1);
     assert_eq!(slru.len(), 2, "SLRU: update should not increase len");
     assert_eq!(slru.get(&1), Some(&100), "SLRU: value should be updated");
 
     // GDSF - note: get() returns Option<V>, not Option<&V>
     let mut gdsf = make_gdsf(3);
-    gdsf.put(1, 10, Some(1));
-    gdsf.put(2, 20, Some(1));
-    gdsf.put(1, 100, Some(1));
+    gdsf.put(1, 10, 1);
+    gdsf.put(2, 20, 1);
+    gdsf.put(1, 100, 1);
     assert_eq!(gdsf.len(), 2, "GDSF: update should not increase len");
     assert_eq!(gdsf.get(&1), Some(100), "GDSF: value should be updated");
 }
@@ -850,7 +850,7 @@ fn test_all_caches_clear() {
     // LRU
     let mut lru = make_lru(5);
     for i in 0..5 {
-        lru.put(i, i, None);
+        lru.put(i, i, 1);
     }
     lru.clear();
     assert_eq!(lru.len(), 0, "LRU: clear should empty cache");
@@ -862,7 +862,7 @@ fn test_all_caches_clear() {
     // LFU
     let mut lfu = make_lfu(5);
     for i in 0..5 {
-        lfu.put(i, i, None);
+        lfu.put(i, i, 1);
     }
     lfu.clear();
     assert_eq!(lfu.len(), 0, "LFU: clear should empty cache");
@@ -870,7 +870,7 @@ fn test_all_caches_clear() {
     // LFUDA
     let mut lfuda = make_lfuda(5);
     for i in 0..5 {
-        lfuda.put(i, i, None);
+        lfuda.put(i, i, 1);
     }
     lfuda.clear();
     assert_eq!(lfuda.len(), 0, "LFUDA: clear should empty cache");
@@ -878,7 +878,7 @@ fn test_all_caches_clear() {
     // SLRU
     let mut slru = make_slru(5, 2);
     for i in 0..5 {
-        slru.put(i, i, None);
+        slru.put(i, i, 1);
     }
     slru.clear();
     assert_eq!(slru.len(), 0, "SLRU: clear should empty cache");
@@ -886,7 +886,7 @@ fn test_all_caches_clear() {
     // GDSF
     let mut gdsf = make_gdsf(5);
     for i in 0..5 {
-        gdsf.put(i, i, Some(1));
+        gdsf.put(i, i, 1);
     }
     gdsf.clear();
     assert_eq!(gdsf.len(), 0, "GDSF: clear should empty cache");
@@ -909,21 +909,21 @@ fn test_lru_size_tracking() {
     let mut cache = make_lru_with_max_size(100);
 
     // Insert items with sizes
-    cache.put(1, "a", Some(30)); // size=30, total=30
+    cache.put(1, "a", 30); // size=30, total=30
     assert_eq!(
         cache.current_size(),
         30,
         "Size should be 30 after first insert"
     );
 
-    cache.put(2, "b", Some(40)); // size=40, total=70
+    cache.put(2, "b", 40); // size=40, total=70
     assert_eq!(
         cache.current_size(),
         70,
         "Size should be 70 after second insert"
     );
 
-    cache.put(3, "c", Some(20)); // size=20, total=90
+    cache.put(3, "c", 20); // size=20, total=90
     assert_eq!(
         cache.current_size(),
         90,
@@ -942,7 +942,7 @@ fn test_lru_size_tracking_accumulates() {
 
     // Insert multiple items and verify size accumulates
     for i in 0..10 {
-        cache.put(i, format!("value{}", i), Some(50));
+        cache.put(i, format!("value{}", i), 50);
     }
 
     assert_eq!(
@@ -958,14 +958,14 @@ fn test_lru_entry_count_eviction_updates_size() {
     // Create cache with entry count limit of 3
     let mut cache = make_lru_with_limits(3, 1000);
 
-    cache.put(1, "a", Some(30));
-    cache.put(2, "b", Some(40));
-    cache.put(3, "c", Some(50));
+    cache.put(1, "a", 30);
+    cache.put(2, "b", 40);
+    cache.put(3, "c", 50);
     assert_eq!(cache.current_size(), 120);
     assert_eq!(cache.len(), 3);
 
     // Insert 4th item - triggers count-based eviction of key 1
-    cache.put(4, "d", Some(60));
+    cache.put(4, "d", 60);
 
     assert!(
         cache.get(&1).is_none(),
@@ -980,9 +980,9 @@ fn test_lru_entry_count_eviction_updates_size() {
 fn test_lfu_size_tracking() {
     let mut cache = make_lfu_with_max_size(1000);
 
-    cache.put(1, "a", Some(100));
-    cache.put(2, "b", Some(200));
-    cache.put(3, "c", Some(150));
+    cache.put(1, "a", 100);
+    cache.put(2, "b", 200);
+    cache.put(3, "c", 150);
 
     assert_eq!(cache.current_size(), 450, "Total size should be 450");
     assert_eq!(cache.len(), 3);
@@ -992,8 +992,8 @@ fn test_lfu_size_tracking() {
 fn test_lfuda_size_tracking() {
     let mut cache = make_lfuda_with_max_size(1000);
 
-    cache.put(1, "a", Some(100));
-    cache.put(2, "b", Some(200));
+    cache.put(1, "a", 100);
+    cache.put(2, "b", 200);
 
     assert_eq!(cache.current_size(), 300, "Total size should be 300");
 }
@@ -1002,9 +1002,9 @@ fn test_lfuda_size_tracking() {
 fn test_slru_size_tracking() {
     let mut cache = make_slru_with_max_size(1000);
 
-    cache.put(1, "a", Some(100));
-    cache.put(2, "b", Some(200));
-    cache.put(3, "c", Some(150));
+    cache.put(1, "a", 100);
+    cache.put(2, "b", 200);
+    cache.put(3, "c", 150);
 
     assert_eq!(cache.current_size(), 450, "Total size should be 450");
 }
@@ -1013,8 +1013,8 @@ fn test_slru_size_tracking() {
 fn test_size_reset_on_clear() {
     let mut cache = make_lru_with_max_size(1000);
 
-    cache.put(1, "a", Some(30));
-    cache.put(2, "b", Some(40));
+    cache.put(1, "a", 30);
+    cache.put(2, "b", 40);
     assert_eq!(cache.current_size(), 70);
 
     cache.clear();
@@ -1058,16 +1058,16 @@ fn test_lru_capacity_one() {
     // Edge case: cache that can only hold 1 item
     let mut cache = make_lru(1);
 
-    cache.put(1, 10, None);
+    cache.put(1, 10, 1);
     assert_eq!(cache.get(&1), Some(&10));
 
     // Second insert immediately evicts first
-    cache.put(2, 20, None);
+    cache.put(2, 20, 1);
     assert!(cache.get(&1).is_none(), "Key 1 should be evicted");
     assert_eq!(cache.get(&2), Some(&20), "Key 2 should be present");
 
     // Third insert evicts second
-    cache.put(3, 30, None);
+    cache.put(3, 30, 1);
     assert!(cache.get(&2).is_none(), "Key 2 should be evicted");
     assert_eq!(cache.get(&3), Some(&30), "Key 3 should be present");
 }
@@ -1076,17 +1076,17 @@ fn test_lru_capacity_one() {
 fn test_lru_update_moves_to_mru() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
     // LRU order: 1 -> 2 -> 3
 
     // Update key 1 - should move to MRU position
-    cache.put(1, 100, None);
+    cache.put(1, 100, 1);
     // LRU order should now be: 2 -> 3 -> 1
 
     // Insert new key - should evict 2 (now LRU), not 1
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     assert!(
         cache.get(&2).is_none(),
@@ -1107,7 +1107,7 @@ fn test_lru_reverse_access_order() {
 
     // Insert 1, 2, 3, 4, 5
     for i in 1..=5 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
     // LRU order: 1 -> 2 -> 3 -> 4 -> 5
 
@@ -1118,7 +1118,7 @@ fn test_lru_reverse_access_order() {
     // LRU order should now be: 5 -> 4 -> 3 -> 2 -> 1 (reversed)
 
     // Insert new key - should evict 5 (now LRU)
-    cache.put(6, 60, None);
+    cache.put(6, 60, 1);
     assert!(
         cache.get(&5).is_none(),
         "Key 5 should be evicted (was LRU after reverse access)"
@@ -1130,20 +1130,20 @@ fn test_lru_reverse_access_order() {
 fn test_lru_remove_and_reinsert() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Remove middle item
     assert_eq!(cache.remove(&2), Some(20));
     assert_eq!(cache.len(), 2);
 
     // Reinsert - should go to MRU position
-    cache.put(2, 200, None);
+    cache.put(2, 200, 1);
     // LRU order: 1 -> 3 -> 2
 
     // Insert new key - should evict 1
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
     assert!(cache.get(&1).is_none(), "Key 1 should be evicted");
     assert_eq!(
         cache.get(&2),
@@ -1163,29 +1163,29 @@ fn test_lfu_all_equal_frequency_fifo() {
     let mut cache = make_lfu(4);
 
     // Insert 4 items - all have freq=1
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // All items have same frequency, FIFO order: 1 -> 2 -> 3 -> 4
 
     // Insert new item - should evict 1 (first in FIFO)
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (FIFO tiebreaker)"
     );
 
     // Insert another - should evict 2 (next in FIFO)
-    cache.put(6, 60, None);
+    cache.put(6, 60, 1);
     assert!(
         cache.get(&2).is_none(),
         "Key 2 should be evicted (FIFO tiebreaker)"
     );
 
     // Insert another - should evict 3
-    cache.put(7, 70, None);
+    cache.put(7, 70, 1);
     assert!(
         cache.get(&3).is_none(),
         "Key 3 should be evicted (FIFO tiebreaker)"
@@ -1197,9 +1197,9 @@ fn test_lfu_new_item_lowest_frequency() {
     // New item has freq=1, could be immediately evicted
     let mut cache = make_lfu(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Access all items many times - they all have high frequency
     for _ in 0..10 {
@@ -1210,12 +1210,12 @@ fn test_lfu_new_item_lowest_frequency() {
     // Frequencies: 1=11, 2=11, 3=11
 
     // Insert new item (freq=1), then another (freq=1)
-    cache.put(4, 40, None); // Evicts based on FIFO among freq=11 items
+    cache.put(4, 40, 1); // Evicts based on FIFO among freq=11 items
     let _first_evicted = (1..=3).find(|&i| cache.get(&i).is_none());
 
     // Insert another - the NEW item (4) has freq=1, much lower than others
     // If freq=1 ties with remaining items at freq=11, FIFO applies
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // Key 4 should be evicted because it has lowest freq (1)
     assert!(
@@ -1229,14 +1229,14 @@ fn test_lfu_new_item_lowest_frequency() {
 fn test_lfu_capacity_one() {
     let mut cache = make_lfu(1);
 
-    cache.put(1, 10, None);
+    cache.put(1, 10, 1);
     // Access many times
     for _ in 0..100 {
         cache.get(&1);
     }
 
     // Even with high frequency, must be evicted when new item comes
-    cache.put(2, 20, None);
+    cache.put(2, 20, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 must be evicted (capacity=1)"
@@ -1248,9 +1248,9 @@ fn test_lfu_capacity_one() {
 fn test_lfu_update_preserves_frequency() {
     let mut cache = make_lfu(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Build up frequency for key 1
     for _ in 0..10 {
@@ -1259,10 +1259,10 @@ fn test_lfu_update_preserves_frequency() {
     // freq: 1=11, 2=1, 3=1
 
     // Update key 1's value - should preserve high frequency
-    cache.put(1, 100, None);
+    cache.put(1, 100, 1);
 
     // Insert new item - should evict 2 or 3 (low freq), NOT key 1
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     assert!(
         cache.get(&1).is_some(),
@@ -1282,19 +1282,19 @@ fn test_slru_all_in_probationary() {
 
     // Insert 5 items, access each only once (no promotion)
     for i in 1..=5 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
     // All items in probationary, LRU order: 1 -> 2 -> 3 -> 4 -> 5
 
     // Insert new item - should evict from probationary (key 1)
-    cache.put(6, 60, None);
+    cache.put(6, 60, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (LRU in probationary)"
     );
 
     // Continue inserting - should keep evicting from probationary
-    cache.put(7, 70, None);
+    cache.put(7, 70, 1);
     assert!(cache.get(&2).is_none(), "Key 2 should be evicted");
 }
 
@@ -1304,8 +1304,8 @@ fn test_slru_protected_full_demotion() {
     let mut cache = make_slru(4, 2);
 
     // Insert and promote 2 items to fill protected
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
     cache.get(&1); // Access to start promotion
     cache.get(&1); // Second access promotes to protected
     cache.get(&2);
@@ -1313,8 +1313,8 @@ fn test_slru_protected_full_demotion() {
                    // Protected: {1, 2}, Probationary: empty
 
     // Add items to probationary
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
     // Protected: {1, 2}, Probationary: {3, 4}
 
     // Promote key 3 - protected is full, so key 1 (oldest) should be demoted
@@ -1324,7 +1324,7 @@ fn test_slru_protected_full_demotion() {
 
     // Insert new item - should evict from probationary
     // Depending on implementation, either demoted key 1 or key 4 is LRU
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     // Key 2 and 3 should be safe (in protected)
     assert!(cache.get(&2).is_some(), "Key 2 should remain (protected)");
@@ -1335,8 +1335,8 @@ fn test_slru_protected_full_demotion() {
 fn test_slru_access_in_protected_stays() {
     let mut cache = make_slru(4, 2);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
 
     // Promote both to protected
     cache.get(&1);
@@ -1348,8 +1348,8 @@ fn test_slru_access_in_protected_stays() {
     cache.get(&1);
 
     // Add probationary items
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // Promote key 3 - key 2 should be demoted (LRU in protected)
     cache.get(&3);
@@ -1357,7 +1357,7 @@ fn test_slru_access_in_protected_stays() {
 
     // Key 1 should still be in protected (was accessed, moved to MRU)
     // Key 2 should be demoted to probationary
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
 
     assert!(
         cache.get(&1).is_some(),
@@ -1376,7 +1376,7 @@ fn test_slru_probationary_larger_than_protected() {
 
     // Fill cache
     for i in 1..=5 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
 
     // Promote only key 5 to protected
@@ -1386,7 +1386,7 @@ fn test_slru_probationary_larger_than_protected() {
 
     // Insert 4 new items - should evict all original probationary items
     for i in 6..=9 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
 
     // Key 5 should survive (protected)
@@ -1407,14 +1407,14 @@ fn test_lfuda_all_equal_priority() {
     let mut cache = make_lfuda(4);
 
     // Insert 4 items - all have same initial priority
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
-    cache.put(4, 40, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
+    cache.put(4, 40, 1);
 
     // No accesses - all have equal priority
     // Should use FIFO as tiebreaker
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (FIFO among equal priority)"
@@ -1425,18 +1425,18 @@ fn test_lfuda_all_equal_priority() {
 fn test_lfuda_aging_reduces_priority_gap() {
     let mut cache = make_lfuda(3);
 
-    cache.put(1, 10, None);
+    cache.put(1, 10, 1);
     // Build very high frequency for key 1
     for _ in 0..50 {
         cache.get(&1);
     }
 
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Force multiple evictions to increase global age
     for i in 100..120 {
-        cache.put(i, i, None);
+        cache.put(i, i, 1);
     }
 
     // At this point, high global age means new items have boosted priority
@@ -1448,13 +1448,13 @@ fn test_lfuda_aging_reduces_priority_gap() {
 fn test_lfuda_capacity_one() {
     let mut cache = make_lfuda(1);
 
-    cache.put(1, 10, None);
+    cache.put(1, 10, 1);
     for _ in 0..100 {
         cache.get(&1);
     }
 
     // Must evict even with high priority
-    cache.put(2, 20, None);
+    cache.put(2, 20, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 must be evicted (capacity=1)"
@@ -1473,8 +1473,8 @@ fn test_lfuda_cap_len_is_empty() {
     assert_eq!(cache.len(), 0);
 
     // Add some items
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
 
     // Test len() and is_empty() with items
     assert!(!cache.is_empty());
@@ -1497,14 +1497,14 @@ fn test_lfuda_current_size_max_size() {
     assert_eq!(cache.current_size(), 0);
 
     // Add items with explicit sizes
-    cache.put(1, 10, Some(100));
+    cache.put(1, 10, 100);
     assert_eq!(cache.current_size(), 100);
 
-    cache.put(2, 20, Some(200));
+    cache.put(2, 20, 200);
     assert_eq!(cache.current_size(), 300);
 
     // Update existing key with different size
-    cache.put(1, 15, Some(150));
+    cache.put(1, 15, 150);
     assert_eq!(cache.current_size(), 350);
 
     // Remove item and verify size decreases
@@ -1524,15 +1524,15 @@ fn test_lfuda_global_age_tracking() {
     assert_eq!(cache.global_age(), 0);
 
     // Fill cache
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Global age should still be 0 (no evictions yet)
     assert_eq!(cache.global_age(), 0);
 
     // Trigger eviction - global age should increase
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
     let age_after_first_eviction = cache.global_age();
     // LFUDA sets global age to evicted item's priority (freq + age_at_insertion)
     // Evicted item had priority = 1 + 0 = 1
@@ -1542,7 +1542,7 @@ fn test_lfuda_global_age_tracking() {
     );
 
     // More evictions should continue increasing age
-    cache.put(5, 50, None);
+    cache.put(5, 50, 1);
     let age_after_second = cache.global_age();
     assert!(
         age_after_second >= age_after_first_eviction,
@@ -1575,8 +1575,8 @@ fn test_lfuda_record_miss() {
 fn test_lfuda_get_mut_modifies_value() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(10);
 
-    cache.put("a", 10, None);
-    cache.put("b", 20, None);
+    cache.put("a", 10, 1);
+    cache.put("b", 20, 1);
 
     // Use get_mut to modify value
     if let Some(val) = cache.get_mut(&"a") {
@@ -1594,9 +1594,9 @@ fn test_lfuda_get_mut_modifies_value() {
 fn test_lfuda_get_mut_affects_priority() {
     let mut cache: LfudaCache<i32, i32> = make_lfuda(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Access key 1 via get_mut to increase its priority
     for _ in 0..5 {
@@ -1609,7 +1609,7 @@ fn test_lfuda_get_mut_affects_priority() {
     assert_eq!(cache.get(&1), Some(&15));
 
     // Trigger eviction - key 2 or 3 should be evicted, not key 1
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
 
     assert!(
         cache.get(&1).is_some(),
@@ -1622,16 +1622,16 @@ fn test_lfuda_size_eviction_multiple_items() {
     let mut cache: LfudaCache<i32, String> = make_lfuda_with_max_size(100);
 
     // Add several small items
-    cache.put(1, "a".to_string(), Some(25));
-    cache.put(2, "b".to_string(), Some(25));
-    cache.put(3, "c".to_string(), Some(25));
-    cache.put(4, "d".to_string(), Some(25));
+    cache.put(1, "a".to_string(), 25);
+    cache.put(2, "b".to_string(), 25);
+    cache.put(3, "c".to_string(), 25);
+    cache.put(4, "d".to_string(), 25);
 
     assert_eq!(cache.current_size(), 100);
     assert_eq!(cache.len(), 4);
 
     // Adding a large item should evict multiple small items
-    cache.put(5, "large".to_string(), Some(60));
+    cache.put(5, "large".to_string(), 60);
 
     // Should have evicted at least 2 items to make room
     assert!(cache.current_size() <= 100);
@@ -1645,7 +1645,7 @@ fn test_lfuda_pop_updates_global_age() {
 
     // Fill cache
     for i in 1..=5 {
-        cache.put(i, i * 10, None);
+        cache.put(i, i * 10, 1);
     }
 
     // Access some items to create priority differences
@@ -1671,12 +1671,12 @@ fn test_lfuda_put_returns_evicted() {
     let mut cache: LfudaCache<i32, i32> = make_lfuda(3);
 
     // Fill cache
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Next put should return evicted item
-    let evicted = cache.put(4, 40, None);
+    let evicted = cache.put(4, 40, 1);
     assert!(evicted.is_some(), "Should return evicted item");
 
     let (key, value) = evicted.unwrap();
@@ -1689,11 +1689,11 @@ fn test_lfuda_put_returns_evicted() {
 fn test_lfuda_update_existing_key() {
     let mut cache: LfudaCache<i32, i32> = make_lfuda(10);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
 
     // Update existing key
-    let old = cache.put(1, 100, None);
+    let old = cache.put(1, 100, 1);
 
     // Should return old value wrapped in tuple
     assert_eq!(old, Some((1, 10)));
@@ -1715,12 +1715,12 @@ fn test_gdsf_all_same_size_and_frequency() {
     let mut cache = make_gdsf(4);
 
     for i in 1..=4 {
-        cache.put(i, i * 10, Some(10)); // All size=10
+        cache.put(i, i * 10, 10); // All size=10
     }
     // All have priority = 1/10 = 0.1
 
     // Should use FIFO as tiebreaker
-    cache.put(5, 50, Some(10));
+    cache.put(5, 50, 10);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (FIFO tiebreaker)"
@@ -1732,17 +1732,17 @@ fn test_gdsf_tiny_vs_huge_size() {
     let mut cache = make_gdsf(3);
 
     // Huge object with moderate frequency
-    cache.put(1, 10, Some(1000));
+    cache.put(1, 10, 1000);
     for _ in 0..10 {
         cache.get(&1); // freq=11, priority = 11/1000 = 0.011
     }
 
     // Tiny objects with low frequency
-    cache.put(2, 20, Some(1)); // freq=1, priority = 1/1 = 1.0
-    cache.put(3, 30, Some(1)); // freq=1, priority = 1/1 = 1.0
+    cache.put(2, 20, 1); // freq=1, priority = 1/1 = 1.0
+    cache.put(3, 30, 1); // freq=1, priority = 1/1 = 1.0
 
     // Insert another - huge object has much lower priority despite more accesses
-    cache.put(4, 40, Some(1));
+    cache.put(4, 40, 1);
 
     assert!(
         cache.get(&1).is_none(),
@@ -1757,9 +1757,9 @@ fn test_gdsf_size_one_equals_lfu() {
     // When all sizes are 1, GDSF should behave like LFU
     let mut cache = make_gdsf(3);
 
-    cache.put(1, 10, Some(1));
-    cache.put(2, 20, Some(1));
-    cache.put(3, 30, Some(1));
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Build frequency for key 1
     for _ in 0..10 {
@@ -1770,7 +1770,7 @@ fn test_gdsf_size_one_equals_lfu() {
     }
     // Priorities (freq/1): 1=11, 2=6, 3=1
 
-    cache.put(4, 40, Some(1));
+    cache.put(4, 40, 1);
     assert!(
         cache.get(&3).is_none(),
         "Key 3 should be evicted (lowest freq when size=1)"
@@ -1782,17 +1782,17 @@ fn test_gdsf_frequency_can_overcome_size() {
     let mut cache = make_gdsf(3);
 
     // Large object with VERY high frequency
-    cache.put(1, 10, Some(100));
+    cache.put(1, 10, 100);
     for _ in 0..500 {
         cache.get(&1); // freq=501, priority = 501/100 = 5.01
     }
 
     // Small objects with low frequency
-    cache.put(2, 20, Some(1)); // freq=1, priority = 1/1 = 1.0
-    cache.put(3, 30, Some(1)); // freq=1, priority = 1/1 = 1.0
+    cache.put(2, 20, 1); // freq=1, priority = 1/1 = 1.0
+    cache.put(3, 30, 1); // freq=1, priority = 1/1 = 1.0
 
     // Insert new - small objects have lower priority
-    cache.put(4, 40, Some(1));
+    cache.put(4, 40, 1);
 
     // Key 2 or 3 should be evicted (priority 1.0 < 5.01)
     assert!(
@@ -1807,12 +1807,12 @@ fn test_gdsf_frequency_can_overcome_size() {
 fn test_gdsf_capacity_one() {
     let mut cache = make_gdsf(1);
 
-    cache.put(1, 10, Some(1));
+    cache.put(1, 10, 1);
     for _ in 0..100 {
         cache.get(&1);
     }
 
-    cache.put(2, 20, Some(1));
+    cache.put(2, 20, 1);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 must be evicted (capacity=1)"
@@ -1842,8 +1842,8 @@ fn test_operations_on_empty_cache() {
 fn test_remove_nonexistent_key() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
 
     // Remove key that doesn't exist
     assert_eq!(cache.remove(&99), None);
@@ -1858,16 +1858,16 @@ fn test_remove_nonexistent_key() {
 fn test_insert_after_clear() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10, None);
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(1, 10, 1);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     cache.clear();
     assert_eq!(cache.len(), 0);
 
     // Insert after clear - should work normally
-    cache.put(4, 40, None);
-    cache.put(5, 50, None);
+    cache.put(4, 40, 1);
+    cache.put(5, 50, 1);
 
     assert_eq!(cache.len(), 2);
     assert_eq!(cache.get(&4), Some(&40));
@@ -1880,7 +1880,7 @@ fn test_rapid_update_same_key() {
 
     // Insert same key many times
     for i in 0..100 {
-        cache.put(1, i, None);
+        cache.put(1, i, 1);
     }
 
     assert_eq!(cache.len(), 1, "Should only have 1 entry");
@@ -1893,7 +1893,7 @@ fn test_alternating_keys() {
 
     // Alternating pattern that causes continuous eviction
     for i in 0..10 {
-        cache.put(i % 3, i, None); // Keys 0, 1, 2, 0, 1, 2, ...
+        cache.put(i % 3, i, 1); // Keys 0, 1, 2, 0, 1, 2, ...
     }
 
     // Should have the last 2 keys inserted
@@ -1904,18 +1904,18 @@ fn test_alternating_keys() {
 fn test_lfu_get_does_not_exist() {
     let mut cache = make_lfu(3);
 
-    cache.put(1, 10, None);
+    cache.put(1, 10, 1);
 
     // Get non-existent key should not affect frequencies
     assert_eq!(cache.get(&99), None);
     assert_eq!(cache.get(&99), None);
 
-    cache.put(2, 20, None);
-    cache.put(3, 30, None);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Key 1 should still be at freq=1 (only the put)
     // Insert new - all equal freq, FIFO
-    cache.put(4, 40, None);
+    cache.put(4, 40, 1);
     assert!(cache.get(&1).is_none(), "Key 1 should be evicted (FIFO)");
 }
 
@@ -1925,13 +1925,13 @@ fn test_gdsf_zero_size_handling() {
 
     // Size 0 edge case - implementation should handle gracefully
     // (might treat as size 1 or have special handling)
-    cache.put(1, 10, Some(0));
-    cache.put(2, 20, Some(1));
-    cache.put(3, 30, Some(1));
+    cache.put(1, 10, 0);
+    cache.put(2, 20, 1);
+    cache.put(3, 30, 1);
 
     // Should not panic, cache should still function
     assert!(cache.len() <= 3);
-    cache.put(4, 40, Some(1));
+    cache.put(4, 40, 1);
     assert!(cache.len() <= 3);
 }
 
@@ -1952,8 +1952,8 @@ fn test_metrics_size_tracking_no_underflow() {
     let mut cache = make_lru_with_limits(2, 1000);
 
     // Insert items with explicit small sizes
-    cache.put(1, "a", Some(1)); // Track as 1 byte
-    cache.put(2, "b", Some(1)); // Track as 1 byte
+    cache.put(1, "a", 1); // Track as 1 byte
+    cache.put(2, "b", 1); // Track as 1 byte
 
     // Current size should be 2
     assert_eq!(cache.current_size(), 2, "Should track 2 bytes");
@@ -1961,7 +1961,7 @@ fn test_metrics_size_tracking_no_underflow() {
     // Insert third item - triggers eviction of key 1
     // On eviction, estimate_object_size() may return a value different from 1
     // This should NOT panic due to subtraction underflow
-    cache.put(3, "c", Some(1));
+    cache.put(3, "c", 1);
 
     // Cache should still function correctly
     assert_eq!(cache.len(), 2);
@@ -1981,19 +1981,15 @@ fn test_metrics_size_mismatch_on_eviction() {
 
     // Insert items with size=1 but the actual values are larger
     // (estimate_object_size will calculate a bigger size)
-    cache.put(1, "hello world this is a long string".to_string(), Some(1));
-    cache.put(2, "another fairly long string value".to_string(), Some(1));
-    cache.put(
-        3,
-        "yet another long string for testing".to_string(),
-        Some(1),
-    );
+    cache.put(1, "hello world this is a long string".to_string(), 1);
+    cache.put(2, "another fairly long string value".to_string(), 1);
+    cache.put(3, "yet another long string for testing".to_string(), 1);
 
     // Force evictions by inserting more items
     // Each eviction will try to subtract estimate_object_size() from metrics
     // which is larger than the 1 byte we recorded on insertion
     for i in 4..10 {
-        cache.put(i, format!("value number {}", i), Some(1));
+        cache.put(i, format!("value number {}", i), 1);
     }
 
     // Should not have panicked, and size should be reasonable
@@ -2031,16 +2027,16 @@ fn test_lru_max_size_triggers_eviction() {
     let mut cache: LruCache<String, i32> = make_lru_with_limits(1000, 100);
 
     // Insert items that fit within max_size
-    cache.put("a".to_string(), 1, Some(30)); // total: 30
-    cache.put("b".to_string(), 2, Some(30)); // total: 60
-    cache.put("c".to_string(), 3, Some(30)); // total: 90
+    cache.put("a".to_string(), 1, 30); // total: 30
+    cache.put("b".to_string(), 2, 30); // total: 60
+    cache.put("c".to_string(), 3, 30); // total: 90
 
     assert_eq!(cache.len(), 3, "Should have 3 items");
     assert_eq!(cache.current_size(), 90, "Size should be 90");
 
     // Insert item that would exceed max_size (90 + 20 = 110 > 100)
     // LRU should evict "a" to stay within max_size
-    cache.put("d".to_string(), 4, Some(20));
+    cache.put("d".to_string(), 4, 20);
 
     // Verify LRU respects max_size
     assert!(
@@ -2075,16 +2071,16 @@ fn test_slru_max_size_triggers_eviction() {
     let mut cache: SlruCache<String, i32> = make_slru_with_limits(1000, 200, 100);
 
     // Insert items that fit within max_size
-    cache.put("a".to_string(), 1, Some(30)); // total: 30
-    cache.put("b".to_string(), 2, Some(30)); // total: 60
-    cache.put("c".to_string(), 3, Some(30)); // total: 90
+    cache.put("a".to_string(), 1, 30); // total: 30
+    cache.put("b".to_string(), 2, 30); // total: 60
+    cache.put("c".to_string(), 3, 30); // total: 90
 
     assert_eq!(cache.len(), 3, "Should have 3 items");
     assert_eq!(cache.current_size(), 90, "Size should be 90");
 
     // Insert item that would exceed max_size (90 + 20 = 110 > 100)
     // SLRU should evict to stay within max_size
-    cache.put("d".to_string(), 4, Some(20));
+    cache.put("d".to_string(), 4, 20);
 
     assert!(
         cache.current_size() <= 100,
@@ -2098,14 +2094,14 @@ fn test_lfu_max_size_triggers_eviction() {
     // Create LFU with large entry capacity but small max_size
     let mut cache: LfuCache<String, i32> = make_lfu_with_max_size(100);
 
-    cache.put("a".to_string(), 1, Some(30));
-    cache.put("b".to_string(), 2, Some(30));
-    cache.put("c".to_string(), 3, Some(30));
+    cache.put("a".to_string(), 1, 30);
+    cache.put("b".to_string(), 2, 30);
+    cache.put("c".to_string(), 3, 30);
 
     assert_eq!(cache.current_size(), 90);
 
     // Insert item that would exceed max_size
-    cache.put("d".to_string(), 4, Some(20));
+    cache.put("d".to_string(), 4, 20);
 
     assert!(
         cache.current_size() <= 100,
@@ -2119,14 +2115,14 @@ fn test_lfuda_max_size_triggers_eviction() {
     // Create LFUDA with large entry capacity but small max_size
     let mut cache: LfudaCache<String, i32> = make_lfuda_with_max_size(100);
 
-    cache.put("a".to_string(), 1, Some(30));
-    cache.put("b".to_string(), 2, Some(30));
-    cache.put("c".to_string(), 3, Some(30));
+    cache.put("a".to_string(), 1, 30);
+    cache.put("b".to_string(), 2, 30);
+    cache.put("c".to_string(), 3, 30);
 
     assert_eq!(cache.current_size(), 90);
 
     // Insert item that would exceed max_size
-    cache.put("d".to_string(), 4, Some(20));
+    cache.put("d".to_string(), 4, 20);
 
     assert!(
         cache.current_size() <= 100,
@@ -2142,14 +2138,14 @@ fn test_slru_max_size_should_evict_multiple_items() {
 
     // Fill with small items
     for i in 0..10 {
-        cache.put(format!("key{}", i), i, Some(10)); // 10 items × 10 bytes = 100
+        cache.put(format!("key{}", i), i, 10); // 10 items × 10 bytes = 100
     }
 
     assert_eq!(cache.len(), 10);
     assert_eq!(cache.current_size(), 100, "Cache should be at max_size");
 
     // Insert a large item (50 bytes) - should evict multiple small items
-    cache.put("big".to_string(), 999, Some(50));
+    cache.put("big".to_string(), 999, 50);
 
     // Expected: evict enough items to fit the new 50-byte item
     // Final size should be <= 100
@@ -2170,9 +2166,9 @@ fn test_slru_max_size_should_evict_multiple_items() {
 #[test]
 fn test_lru_get_mut_updates_value() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     // Mutate value through get_mut
     if let Some(v) = cache.get_mut(&"b") {
@@ -2182,7 +2178,7 @@ fn test_lru_get_mut_updates_value() {
 
     // get_mut should update recency like get does
     // "a" is now LRU (we touched "b" via get_mut, then "b" again via get)
-    cache.put("d", 4, None); // evicts "a"
+    cache.put("d", 4, 1); // evicts "a"
     assert!(cache.get(&"a").is_none());
     assert_eq!(cache.get(&"b"), Some(&20));
 }
@@ -2190,9 +2186,9 @@ fn test_lru_get_mut_updates_value() {
 #[test]
 fn test_lfu_get_mut_updates_value() {
     let mut cache: LfuCache<&str, i32> = make_lfu(3);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2203,9 +2199,9 @@ fn test_lfu_get_mut_updates_value() {
 #[test]
 fn test_lfuda_get_mut_updates_value() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(3);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2216,9 +2212,9 @@ fn test_lfuda_get_mut_updates_value() {
 #[test]
 fn test_slru_get_mut_updates_value() {
     let mut cache: SlruCache<&str, i32> = make_slru(5, 2);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2229,9 +2225,9 @@ fn test_slru_get_mut_updates_value() {
 #[test]
 fn test_gdsf_get_mut_updates_value() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
-    cache.put("a", 1, Some(OBJECT_SIZE));
-    cache.put("b", 2, Some(OBJECT_SIZE));
-    cache.put("c", 3, Some(OBJECT_SIZE));
+    cache.put("a", 1, OBJECT_SIZE);
+    cache.put("b", 2, OBJECT_SIZE);
+    cache.put("c", 3, OBJECT_SIZE);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2251,7 +2247,7 @@ fn test_all_caches_contains() {
     // LRU
     let mut lru: LruCache<&str, i32> = make_lru(3);
     assert!(!lru.contains(&"a"));
-    lru.put("a", 1, None);
+    lru.put("a", 1, 1);
     assert!(lru.contains(&"a"));
     lru.remove(&"a");
     assert!(!lru.contains(&"a"));
@@ -2259,7 +2255,7 @@ fn test_all_caches_contains() {
     // LFU
     let mut lfu: LfuCache<&str, i32> = make_lfu(3);
     assert!(!lfu.contains(&"a"));
-    lfu.put("a", 1, None);
+    lfu.put("a", 1, 1);
     assert!(lfu.contains(&"a"));
     lfu.remove(&"a");
     assert!(!lfu.contains(&"a"));
@@ -2267,7 +2263,7 @@ fn test_all_caches_contains() {
     // LFUDA
     let mut lfuda: LfudaCache<&str, i32> = make_lfuda(3);
     assert!(!lfuda.contains(&"a"));
-    lfuda.put("a", 1, None);
+    lfuda.put("a", 1, 1);
     assert!(lfuda.contains(&"a"));
     lfuda.remove(&"a");
     assert!(!lfuda.contains(&"a"));
@@ -2275,7 +2271,7 @@ fn test_all_caches_contains() {
     // SLRU
     let mut slru: SlruCache<&str, i32> = make_slru(5, 2);
     assert!(!slru.contains(&"a"));
-    slru.put("a", 1, None);
+    slru.put("a", 1, 1);
     assert!(slru.contains(&"a"));
     slru.remove(&"a");
     assert!(!slru.contains(&"a"));
@@ -2283,7 +2279,7 @@ fn test_all_caches_contains() {
     // GDSF
     let mut gdsf: GdsfCache<&str, i32> = make_gdsf(3);
     assert!(!gdsf.contains(&"a"));
-    gdsf.put("a", 1, Some(OBJECT_SIZE));
+    gdsf.put("a", 1, OBJECT_SIZE);
     assert!(gdsf.contains(&"a"));
     gdsf.remove(&"a");
     assert!(!gdsf.contains(&"a"));
@@ -2292,11 +2288,11 @@ fn test_all_caches_contains() {
 #[test]
 fn test_contains_after_eviction() {
     let mut cache: LruCache<&str, i32> = make_lru(2);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
     assert!(cache.contains(&"a"));
 
-    cache.put("c", 3, None); // evicts "a"
+    cache.put("c", 3, 1); // evicts "a"
     assert!(!cache.contains(&"a"));
     assert!(cache.contains(&"b"));
     assert!(cache.contains(&"c"));
@@ -2311,15 +2307,15 @@ fn test_contains_after_eviction() {
 #[test]
 fn test_lru_peek_does_not_affect_eviction() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     // Peek at "a" - should NOT update recency
     assert_eq!(cache.peek(&"a"), Some(&1));
 
     // "a" is still LRU despite peek, so it should be evicted
-    cache.put("d", 4, None);
+    cache.put("d", 4, 1);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT prevent eviction of LRU item"
@@ -2329,9 +2325,9 @@ fn test_lru_peek_does_not_affect_eviction() {
 #[test]
 fn test_lfu_peek_does_not_affect_eviction() {
     let mut cache: LfuCache<&str, i32> = make_lfu(3);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     // Access b and c to increase frequency, but only peek at a
     cache.get(&"b");
@@ -2339,7 +2335,7 @@ fn test_lfu_peek_does_not_affect_eviction() {
     assert_eq!(cache.peek(&"a"), Some(&1));
 
     // "a" should still have lowest frequency and be evicted
-    cache.put("d", 4, None);
+    cache.put("d", 4, 1);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT increase frequency"
@@ -2349,15 +2345,15 @@ fn test_lfu_peek_does_not_affect_eviction() {
 #[test]
 fn test_lfuda_peek_does_not_affect_eviction() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(3);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     cache.get(&"b");
     cache.get(&"c");
     assert_eq!(cache.peek(&"a"), Some(&1));
 
-    cache.put("d", 4, None);
+    cache.put("d", 4, 1);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT increase priority in LFUDA"
@@ -2367,17 +2363,17 @@ fn test_lfuda_peek_does_not_affect_eviction() {
 #[test]
 fn test_slru_peek_does_not_affect_eviction() {
     let mut cache: SlruCache<&str, i32> = make_slru(5, 2);
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
-    cache.put("d", 4, None);
-    cache.put("e", 5, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
+    cache.put("d", 4, 1);
+    cache.put("e", 5, 1);
 
     // Peek at "a" - should NOT promote to protected
     assert_eq!(cache.peek(&"a"), Some(&1));
 
     // "a" should still be evictable from probationary
-    cache.put("f", 6, None);
+    cache.put("f", 6, 1);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT promote items in SLRU"
@@ -2387,16 +2383,16 @@ fn test_slru_peek_does_not_affect_eviction() {
 #[test]
 fn test_gdsf_peek_does_not_affect_eviction() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
-    cache.put("a", 1, Some(OBJECT_SIZE));
-    cache.put("b", 2, Some(OBJECT_SIZE));
-    cache.put("c", 3, Some(OBJECT_SIZE));
+    cache.put("a", 1, OBJECT_SIZE);
+    cache.put("b", 2, OBJECT_SIZE);
+    cache.put("c", 3, OBJECT_SIZE);
 
     // Access b and c to increase frequency, but only peek at a
     cache.get(&"b");
     cache.get(&"c");
     assert_eq!(cache.peek(&"a"), Some(&1));
 
-    cache.put("d", 4, Some(OBJECT_SIZE));
+    cache.put("d", 4, OBJECT_SIZE);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT increase frequency in GDSF"
@@ -2408,7 +2404,7 @@ fn test_peek_nonexistent_key() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
     assert_eq!(cache.peek(&"missing"), None);
 
-    cache.put("a", 1, None);
+    cache.put("a", 1, 1);
     assert_eq!(cache.peek(&"missing"), None);
     assert_eq!(cache.peek(&"a"), Some(&1));
 }
@@ -2424,9 +2420,9 @@ fn test_lru_pop_returns_lru_item() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
     assert_eq!(cache.pop(), None); // empty cache
 
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     // "a" is LRU
     let popped = cache.pop();
@@ -2440,9 +2436,9 @@ fn test_lfu_pop_returns_least_frequent() {
     let mut cache: LfuCache<&str, i32> = make_lfu(3);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     // Access b and c to increase their frequency
     cache.get(&"b");
@@ -2459,9 +2455,9 @@ fn test_lfuda_pop_returns_lowest_priority() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(3);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     cache.get(&"b");
     cache.get(&"c");
@@ -2476,9 +2472,9 @@ fn test_slru_pop_returns_probationary_item() {
     let mut cache: SlruCache<&str, i32> = make_slru(5, 2);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
-    cache.put("c", 3, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
+    cache.put("c", 3, 1);
 
     let popped = cache.pop();
     assert!(popped.is_some());
@@ -2490,9 +2486,9 @@ fn test_gdsf_pop_returns_lowest_priority() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1, Some(OBJECT_SIZE));
-    cache.put("b", 2, Some(OBJECT_SIZE));
-    cache.put("c", 3, Some(OBJECT_SIZE));
+    cache.put("a", 1, OBJECT_SIZE);
+    cache.put("b", 2, OBJECT_SIZE);
+    cache.put("c", 3, OBJECT_SIZE);
 
     cache.get(&"b");
     cache.get(&"c");
@@ -2532,7 +2528,7 @@ fn test_all_caches_cap() {
 #[test]
 fn test_all_caches_record_miss() {
     let mut lru: LruCache<&str, i32> = make_lru(3);
-    lru.put("a", 1, None);
+    lru.put("a", 1, 1);
     lru.record_miss(100);
     lru.record_miss(200);
     assert_eq!(lru.len(), 1); // cache contents unchanged
@@ -2543,22 +2539,22 @@ fn test_all_caches_record_miss() {
     );
 
     let mut lfu: LfuCache<&str, i32> = make_lfu(3);
-    lfu.put("a", 1, None);
+    lfu.put("a", 1, 1);
     lfu.record_miss(100);
     assert_eq!(lfu.len(), 1);
 
     let mut lfuda: LfudaCache<&str, i32> = make_lfuda(3);
-    lfuda.put("a", 1, None);
+    lfuda.put("a", 1, 1);
     lfuda.record_miss(100);
     assert_eq!(lfuda.len(), 1);
 
     let mut slru: SlruCache<&str, i32> = make_slru(5, 2);
-    slru.put("a", 1, None);
+    slru.put("a", 1, 1);
     slru.record_miss(100);
     assert_eq!(slru.len(), 1);
 
     let mut gdsf: GdsfCache<&str, i32> = make_gdsf(3);
-    gdsf.put("a", 1, Some(OBJECT_SIZE));
+    gdsf.put("a", 1, OBJECT_SIZE);
     gdsf.record_miss(100);
     assert_eq!(gdsf.len(), 1);
 }
@@ -2589,10 +2585,10 @@ fn test_all_caches_algorithm_name() {
 fn test_all_caches_metrics_after_operations() {
     // LRU metrics
     let mut lru: LruCache<&str, i32> = make_lru(2);
-    lru.put("a", 1, None);
-    lru.put("b", 2, None);
+    lru.put("a", 1, 1);
+    lru.put("b", 2, 1);
     lru.get(&"a"); // hit
-    lru.put("c", 3, None); // eviction
+    lru.put("c", 3, 1); // eviction
 
     let metrics = lru.metrics();
     assert!(
@@ -2614,10 +2610,10 @@ fn test_all_caches_metrics_after_operations() {
 
     // LFU metrics
     let mut lfu: LfuCache<&str, i32> = make_lfu(2);
-    lfu.put("a", 1, None);
-    lfu.put("b", 2, None);
+    lfu.put("a", 1, 1);
+    lfu.put("b", 2, 1);
     lfu.get(&"a");
-    lfu.put("c", 3, None);
+    lfu.put("c", 3, 1);
 
     let metrics = lfu.metrics();
     assert!(
@@ -2627,10 +2623,10 @@ fn test_all_caches_metrics_after_operations() {
 
     // LFUDA metrics
     let mut lfuda: LfudaCache<&str, i32> = make_lfuda(2);
-    lfuda.put("a", 1, None);
-    lfuda.put("b", 2, None);
+    lfuda.put("a", 1, 1);
+    lfuda.put("b", 2, 1);
     lfuda.get(&"a");
-    lfuda.put("c", 3, None);
+    lfuda.put("c", 3, 1);
 
     let metrics = lfuda.metrics();
     assert!(
@@ -2640,8 +2636,8 @@ fn test_all_caches_metrics_after_operations() {
 
     // SLRU metrics
     let mut slru: SlruCache<&str, i32> = make_slru(3, 1);
-    slru.put("a", 1, None);
-    slru.put("b", 2, None);
+    slru.put("a", 1, 1);
+    slru.put("b", 2, 1);
     slru.get(&"a");
 
     let metrics = slru.metrics();
@@ -2652,10 +2648,10 @@ fn test_all_caches_metrics_after_operations() {
 
     // GDSF metrics
     let mut gdsf: GdsfCache<&str, i32> = make_gdsf(2);
-    gdsf.put("a", 1, Some(OBJECT_SIZE));
-    gdsf.put("b", 2, Some(OBJECT_SIZE));
+    gdsf.put("a", 1, OBJECT_SIZE);
+    gdsf.put("b", 2, OBJECT_SIZE);
     gdsf.get(&"a");
-    gdsf.put("c", 3, Some(OBJECT_SIZE));
+    gdsf.put("c", 3, OBJECT_SIZE);
 
     let metrics = gdsf.metrics();
     assert!(
@@ -2676,7 +2672,7 @@ fn test_all_caches_metrics_after_operations() {
 #[should_panic(expected = "not yet implemented")]
 fn test_lru_iter_is_unimplemented() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1, None);
+    cache.put("a", 1, 1);
     let _iter = cache.iter();
 }
 
@@ -2684,7 +2680,7 @@ fn test_lru_iter_is_unimplemented() {
 #[should_panic(expected = "not yet implemented")]
 fn test_lru_iter_mut_is_unimplemented() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1, None);
+    cache.put("a", 1, 1);
     let _iter = cache.iter_mut();
 }
 
@@ -2697,11 +2693,11 @@ fn test_lfuda_global_age_increases_on_eviction() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(2);
     assert_eq!(cache.global_age(), 0);
 
-    cache.put("a", 1, None);
-    cache.put("b", 2, None);
+    cache.put("a", 1, 1);
+    cache.put("b", 2, 1);
 
     // Trigger eviction to increase global age
-    cache.put("c", 3, None);
+    cache.put("c", 3, 1);
     // Global age should have increased (set to evicted item's priority)
     // The exact value depends on implementation - we just verify the method works
     let _age_after = cache.global_age();
@@ -2712,11 +2708,11 @@ fn test_gdsf_global_age_increases_on_eviction() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(2);
     assert!((cache.global_age() - 0.0).abs() < f64::EPSILON);
 
-    cache.put("a", 1, Some(OBJECT_SIZE));
-    cache.put("b", 2, Some(OBJECT_SIZE));
+    cache.put("a", 1, OBJECT_SIZE);
+    cache.put("b", 2, OBJECT_SIZE);
 
     // Trigger eviction
-    cache.put("c", 3, Some(OBJECT_SIZE));
+    cache.put("c", 3, OBJECT_SIZE);
     let age_after = cache.global_age();
     assert!(
         age_after >= 0.0,
@@ -2737,9 +2733,9 @@ fn test_slru_protected_max_size() {
 #[allow(deprecated)]
 fn test_gdsf_pop_key() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
-    cache.put("a", 1, Some(OBJECT_SIZE));
-    cache.put("b", 2, Some(OBJECT_SIZE));
-    cache.put("c", 3, Some(OBJECT_SIZE));
+    cache.put("a", 1, OBJECT_SIZE);
+    cache.put("b", 2, OBJECT_SIZE);
+    cache.put("c", 3, OBJECT_SIZE);
 
     // pop_key removes a specific key
     let removed = cache.pop_key(&"b");

--- a/tests/correctness_tests.rs
+++ b/tests/correctness_tests.rs
@@ -146,9 +146,9 @@ fn test_lru_evicts_least_recently_used() {
     let mut cache = make_lru(3);
 
     // Fill cache: order of insertion determines initial LRU order
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
     // LRU order: 1 (LRU) -> 2 -> 3 (MRU)
 
     // Verify all present before any eviction
@@ -158,7 +158,7 @@ fn test_lru_evicts_least_recently_used() {
     // After gets: LRU order is now 1 -> 2 -> 3 (order of access)
 
     // Insert new key - should evict key 1 (LRU)
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     // VALIDATE EVICTION: Key 1 should be evicted
     assert!(
@@ -171,7 +171,7 @@ fn test_lru_evicts_least_recently_used() {
     // After gets: LRU order is 2 -> 3 -> 4
 
     // Insert another - should evict key 2 (now LRU)
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // VALIDATE EVICTION: Key 2 should be evicted
     assert!(
@@ -189,26 +189,26 @@ fn test_lru_eviction_order_is_predictable() {
 
     // Fill cache with keys 0..4
     for i in 0..5 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
     // LRU order: 0 (LRU) -> 1 -> 2 -> 3 -> 4 (MRU)
 
     // Insert key 5 - should evict key 0
-    cache.put(5, 50);
+    cache.put(5, 50, None);
     assert!(
         cache.get(&0).is_none(),
         "First eviction: Key 0 should be evicted"
     );
 
     // Insert key 6 - should evict key 1
-    cache.put(6, 60);
+    cache.put(6, 60, None);
     assert!(
         cache.get(&1).is_none(),
         "Second eviction: Key 1 should be evicted"
     );
 
     // Insert key 7 - should evict key 2
-    cache.put(7, 70);
+    cache.put(7, 70, None);
     assert!(
         cache.get(&2).is_none(),
         "Third eviction: Key 2 should be evicted"
@@ -227,9 +227,9 @@ fn test_lru_get_updates_recency() {
     let mut cache = make_lru(3);
 
     // Fill cache
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
     // LRU order: 1 (LRU) -> 2 -> 3 (MRU)
 
     // Access key 1 to make it recently used
@@ -237,7 +237,7 @@ fn test_lru_get_updates_recency() {
     // LRU order: 2 (LRU) -> 3 -> 1 (MRU)
 
     // Insert new key - should evict key 2 (now LRU), NOT key 1
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     // VALIDATE: Key 2 evicted (not key 1 which was accessed)
     assert!(
@@ -266,9 +266,9 @@ fn test_lfu_evicts_least_frequently_used() {
     let mut cache = make_lfu(3);
 
     // Fill cache
-    cache.put(1, 10); // freq=1
-    cache.put(2, 20); // freq=1
-    cache.put(3, 30); // freq=1
+    cache.put(1, 10, None); // freq=1
+    cache.put(2, 20, None); // freq=1
+    cache.put(3, 30, None); // freq=1
 
     // Access key 1 and 2 to increase their frequency
     cache.get(&1); // freq=2
@@ -278,7 +278,7 @@ fn test_lfu_evicts_least_frequently_used() {
     // Frequencies: key1=3, key2=2, key3=1 (lowest)
 
     // Insert new key - should evict key 3 (lowest frequency)
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     // VALIDATE EVICTION: Key 3 should be evicted (freq=1)
     assert!(
@@ -294,9 +294,9 @@ fn test_lfu_evicts_least_frequently_used() {
 fn test_lfu_frequency_accumulates() {
     let mut cache = make_lfu(3);
 
-    cache.put("hot", 1);
-    cache.put("warm", 2);
-    cache.put("cold", 3);
+    cache.put("hot", 1, None);
+    cache.put("warm", 2, None);
+    cache.put("cold", 3, None);
 
     // Access "hot" many times (freq=11)
     for _ in 0..10 {
@@ -311,7 +311,7 @@ fn test_lfu_frequency_accumulates() {
     // Frequencies: hot=11, warm=4, cold=1 (lowest)
 
     // Insert new item - should evict "cold"
-    cache.put("new", 4);
+    cache.put("new", 4, None);
 
     // VALIDATE EVICTION: "cold" should be evicted (freq=1)
     assert!(
@@ -328,12 +328,12 @@ fn test_lfu_same_frequency_uses_fifo() {
     let mut cache = make_lfu(3);
 
     // Insert 3 items - all have same frequency (1)
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Insert new item - should evict key 1 (first inserted among same frequency)
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     // VALIDATE EVICTION: Key 1 should be evicted (FIFO among same freq)
     assert!(
@@ -342,7 +342,7 @@ fn test_lfu_same_frequency_uses_fifo() {
     );
 
     // Insert another - should evict key 2 (next in FIFO order)
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // VALIDATE EVICTION: Key 2 should be evicted (FIFO)
     assert!(
@@ -366,9 +366,9 @@ fn test_lfuda_evicts_lowest_priority() {
     let mut cache = make_lfuda(3);
 
     // Fill cache
-    cache.put(1, 10); // priority = freq + age = 1 + 0 = 1
-    cache.put(2, 20); // priority = 1 + 0 = 1
-    cache.put(3, 30); // priority = 1 + 0 = 1
+    cache.put(1, 10, None); // priority = freq + age = 1 + 0 = 1
+    cache.put(2, 20, None); // priority = 1 + 0 = 1
+    cache.put(3, 30, None); // priority = 1 + 0 = 1
 
     // Access key 1 and 2 to increase their priority
     cache.get(&1); // priority increases
@@ -378,7 +378,7 @@ fn test_lfuda_evicts_lowest_priority() {
     // Key 3 has lowest priority (only initial put, no gets)
 
     // Insert new key - should evict key 3
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     // VALIDATE EVICTION: Key 3 should be evicted (lowest priority)
     assert!(
@@ -398,9 +398,9 @@ fn test_lfuda_aging_helps_new_items() {
     let mut cache = make_lfuda(3);
 
     // Insert items
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Access all items to increase frequency
     for _ in 0..5 {
@@ -411,8 +411,8 @@ fn test_lfuda_aging_helps_new_items() {
 
     // Now evict and insert several times to increase global age
     // Each eviction increases the age
-    cache.put(4, 40); // evicts one item, age increases
-    cache.put(5, 50); // evicts another, age increases more
+    cache.put(4, 40, None); // evicts one item, age increases
+    cache.put(5, 50, None); // evicts another, age increases more
 
     // New items benefit from the elevated global age
     // The surviving items should be those with highest effective priority
@@ -424,10 +424,10 @@ fn test_lfuda_basic_eviction() {
     let mut cache = make_lfuda(4);
 
     // Fill cache
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // Access first two items more frequently
     for _ in 0..3 {
@@ -436,7 +436,7 @@ fn test_lfuda_basic_eviction() {
     }
 
     // Insert new item - should evict 3 or 4 (lowest frequency)
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // VALIDATE EVICTION: One of 3 or 4 should be evicted (both have freq=1)
     let key3_evicted = cache.get(&3).is_none();
@@ -467,10 +467,10 @@ fn test_slru_promotion_to_protected() {
     let mut cache = make_slru(4, 2);
 
     // Insert items - they start in probationary
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // Access key 1 to promote it to protected segment
     cache.get(&1);
@@ -484,7 +484,7 @@ fn test_slru_promotion_to_protected() {
     // Probationary LRU order: 3 (LRU) -> 4 (MRU)
 
     // Insert new item - should evict from probationary (LRU in probationary = 3)
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // VALIDATE EVICTION: Key 3 should be evicted from probationary
     assert!(
@@ -502,10 +502,10 @@ fn test_slru_probationary_evicted_first() {
     let mut cache = make_slru(4, 2);
 
     // Insert 4 items (all in probationary initially)
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // Promote keys 3 and 4 to protected by accessing them
     cache.get(&3);
@@ -517,7 +517,7 @@ fn test_slru_probationary_evicted_first() {
     // Probationary LRU order: 1 (LRU) -> 2 (MRU)
 
     // Insert new item - should evict key 1 (LRU in probationary)
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // VALIDATE EVICTION: Key 1 should be evicted (LRU in probationary)
     assert!(
@@ -540,10 +540,10 @@ fn test_slru_eviction_order_in_probationary() {
     let mut cache = make_slru(4, 1);
 
     // Insert 4 items
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // Promote only key 4 to protected
     cache.get(&4);
@@ -552,19 +552,19 @@ fn test_slru_eviction_order_in_probationary() {
     // Probationary: 1 (LRU) -> 2 -> 3 (MRU), Protected: 4
 
     // Insert new items and verify eviction order from probationary
-    cache.put(5, 50);
+    cache.put(5, 50, None);
     assert!(
         cache.get(&1).is_none(),
         "First eviction: Key 1 should be evicted"
     );
 
-    cache.put(6, 60);
+    cache.put(6, 60, None);
     assert!(
         cache.get(&2).is_none(),
         "Second eviction: Key 2 should be evicted"
     );
 
-    cache.put(7, 70);
+    cache.put(7, 70, None);
     assert!(
         cache.get(&3).is_none(),
         "Third eviction: Key 3 should be evicted"
@@ -589,9 +589,9 @@ fn test_gdsf_prefers_smaller_objects() {
     let mut cache = make_gdsf(3);
 
     // Insert items with different sizes, same frequency
-    cache.put(1, 10, 100); // Large object (size=100)
-    cache.put(2, 20, 1); // Small object (size=1)
-    cache.put(3, 30, 1); // Small object (size=1)
+    cache.put(1, 10, Some(100)); // Large object (size=100)
+    cache.put(2, 20, Some(1)); // Small object (size=1)
+    cache.put(3, 30, Some(1)); // Small object (size=1)
 
     // All have frequency 1, but priorities differ:
     // Key 1: priority = 1/100 = 0.01
@@ -599,7 +599,7 @@ fn test_gdsf_prefers_smaller_objects() {
     // Key 3: priority = 1/1 = 1.0
 
     // Insert new item - should evict key 1 (lowest priority due to size)
-    cache.put(4, 40, 1);
+    cache.put(4, 40, Some(1));
 
     // VALIDATE EVICTION: Key 1 (large object) should be evicted
     assert!(
@@ -621,9 +621,9 @@ fn test_gdsf_frequency_matters() {
     let mut cache = make_gdsf(3);
 
     // Insert items with same size
-    cache.put(1, 10, OBJECT_SIZE);
-    cache.put(2, 20, OBJECT_SIZE);
-    cache.put(3, 30, OBJECT_SIZE);
+    cache.put(1, 10, Some(OBJECT_SIZE));
+    cache.put(2, 20, Some(OBJECT_SIZE));
+    cache.put(3, 30, Some(OBJECT_SIZE));
 
     // Access key 1 many times to increase frequency
     for _ in 0..10 {
@@ -639,7 +639,7 @@ fn test_gdsf_frequency_matters() {
     // Priorities (freq/size): key1=11/1=11, key2=4/1=4, key3=1/1=1
 
     // Insert new item - should evict key 3 (lowest priority)
-    cache.put(4, 40, OBJECT_SIZE);
+    cache.put(4, 40, Some(OBJECT_SIZE));
 
     // VALIDATE EVICTION: Key 3 should be evicted (lowest frequency)
     assert!(
@@ -655,23 +655,23 @@ fn test_gdsf_size_frequency_tradeoff() {
     let mut cache = make_gdsf(3);
 
     // Large object with high frequency
-    cache.put(1, 10, 100); // size=100
+    cache.put(1, 10, Some(100)); // size=100
     for _ in 0..20 {
         cache.get(&1); // freq=21
     }
     // Priority = 21/100 = 0.21
 
     // Small object with low frequency
-    cache.put(2, 20, 1); // size=1, freq=1
-                         // Priority = 1/1 = 1.0
+    cache.put(2, 20, Some(1)); // size=1, freq=1
+                               // Priority = 1/1 = 1.0
 
     // Another small object
-    cache.put(3, 30, 1); // size=1, freq=1
-                         // Priority = 1/1 = 1.0
+    cache.put(3, 30, Some(1)); // size=1, freq=1
+                               // Priority = 1/1 = 1.0
 
     // Despite high frequency, the large object has lower priority (0.21 < 1.0)
     // Insert new item
-    cache.put(4, 40, 1);
+    cache.put(4, 40, Some(1));
 
     // VALIDATE EVICTION: Large object evicted despite high frequency
     assert!(
@@ -688,25 +688,25 @@ fn test_gdsf_eviction_order_by_priority() {
     let mut cache = make_gdsf(4);
 
     // Insert items with varying size to create predictable priorities
-    cache.put(1, 10, 10); // size=10, priority = 1/10 = 0.1
-    cache.put(2, 20, 5); // size=5,  priority = 1/5 = 0.2
-    cache.put(3, 30, 2); // size=2,  priority = 1/2 = 0.5
-    cache.put(4, 40, 1); // size=1,  priority = 1/1 = 1.0
+    cache.put(1, 10, Some(10)); // size=10, priority = 1/10 = 0.1
+    cache.put(2, 20, Some(5)); // size=5,  priority = 1/5 = 0.2
+    cache.put(3, 30, Some(2)); // size=2,  priority = 1/2 = 0.5
+    cache.put(4, 40, Some(1)); // size=1,  priority = 1/1 = 1.0
 
     // Insert new items and verify eviction order (lowest priority first)
-    cache.put(5, 50, 1);
+    cache.put(5, 50, Some(1));
     assert!(
         cache.get(&1).is_none(),
         "Key 1 evicted first (priority 0.1)"
     );
 
-    cache.put(6, 60, 1);
+    cache.put(6, 60, Some(1));
     assert!(
         cache.get(&2).is_none(),
         "Key 2 evicted second (priority 0.2)"
     );
 
-    cache.put(7, 70, 1);
+    cache.put(7, 70, Some(1));
     assert!(
         cache.get(&3).is_none(),
         "Key 3 evicted third (priority 0.5)"
@@ -729,35 +729,35 @@ fn test_all_caches_basic_operations() {
 
     // LRU
     let mut lru = make_lru(10);
-    lru.put("key", 42);
+    lru.put("key", 42, None);
     assert_eq!(lru.get(&"key"), Some(&42));
     assert_eq!(lru.remove(&"key"), Some(42));
     assert_eq!(lru.get(&"key"), None);
 
     // LFU
     let mut lfu = make_lfu(10);
-    lfu.put("key", 42);
+    lfu.put("key", 42, None);
     assert_eq!(lfu.get(&"key"), Some(&42));
     assert_eq!(lfu.remove(&"key"), Some(42));
     assert_eq!(lfu.get(&"key"), None);
 
     // LFUDA
     let mut lfuda = make_lfuda(10);
-    lfuda.put("key", 42);
+    lfuda.put("key", 42, None);
     assert_eq!(lfuda.get(&"key"), Some(&42));
     assert_eq!(lfuda.remove(&"key"), Some(42));
     assert_eq!(lfuda.get(&"key"), None);
 
     // SLRU
     let mut slru = make_slru(10, 5);
-    slru.put("key", 42);
+    slru.put("key", 42, None);
     assert_eq!(slru.get(&"key"), Some(&42));
     assert_eq!(slru.remove(&"key"), Some(42));
     assert_eq!(slru.get(&"key"), None);
 
     // GDSF - note: get() returns Option<V>, not Option<&V>
     let mut gdsf = make_gdsf(10);
-    gdsf.put("key", 42, 1);
+    gdsf.put("key", 42, Some(1));
     assert_eq!(gdsf.get(&"key"), Some(42));
     // GDSF doesn't have remove(), verify key exists then clear
     gdsf.clear();
@@ -769,35 +769,35 @@ fn test_all_caches_capacity_enforcement() {
     // LRU
     let mut lru = make_lru(3);
     for i in 0..10 {
-        lru.put(i, i);
+        lru.put(i, i, None);
     }
     assert_eq!(lru.len(), 3, "LRU should enforce capacity");
 
     // LFU
     let mut lfu = make_lfu(3);
     for i in 0..10 {
-        lfu.put(i, i);
+        lfu.put(i, i, None);
     }
     assert_eq!(lfu.len(), 3, "LFU should enforce capacity");
 
     // LFUDA
     let mut lfuda = make_lfuda(3);
     for i in 0..10 {
-        lfuda.put(i, i);
+        lfuda.put(i, i, None);
     }
     assert_eq!(lfuda.len(), 3, "LFUDA should enforce capacity");
 
     // SLRU
     let mut slru = make_slru(3, 1);
     for i in 0..10 {
-        slru.put(i, i);
+        slru.put(i, i, None);
     }
     assert_eq!(slru.len(), 3, "SLRU should enforce capacity");
 
     // GDSF
     let mut gdsf = make_gdsf(3);
     for i in 0..10 {
-        gdsf.put(i, i, 1);
+        gdsf.put(i, i, Some(1));
     }
     assert_eq!(gdsf.len(), 3, "GDSF should enforce capacity");
 }
@@ -806,41 +806,41 @@ fn test_all_caches_capacity_enforcement() {
 fn test_all_caches_update_existing_key() {
     // LRU - updating existing key should not change len
     let mut lru = make_lru(3);
-    lru.put(1, 10);
-    lru.put(2, 20);
-    lru.put(1, 100); // Update key 1
+    lru.put(1, 10, None);
+    lru.put(2, 20, None);
+    lru.put(1, 100, None); // Update key 1
     assert_eq!(lru.len(), 2, "LRU: update should not increase len");
     assert_eq!(lru.get(&1), Some(&100), "LRU: value should be updated");
 
     // LFU
     let mut lfu = make_lfu(3);
-    lfu.put(1, 10);
-    lfu.put(2, 20);
-    lfu.put(1, 100);
+    lfu.put(1, 10, None);
+    lfu.put(2, 20, None);
+    lfu.put(1, 100, None);
     assert_eq!(lfu.len(), 2, "LFU: update should not increase len");
     assert_eq!(lfu.get(&1), Some(&100), "LFU: value should be updated");
 
     // LFUDA
     let mut lfuda = make_lfuda(3);
-    lfuda.put(1, 10);
-    lfuda.put(2, 20);
-    lfuda.put(1, 100);
+    lfuda.put(1, 10, None);
+    lfuda.put(2, 20, None);
+    lfuda.put(1, 100, None);
     assert_eq!(lfuda.len(), 2, "LFUDA: update should not increase len");
     assert_eq!(lfuda.get(&1), Some(&100), "LFUDA: value should be updated");
 
     // SLRU
     let mut slru = make_slru(3, 1);
-    slru.put(1, 10);
-    slru.put(2, 20);
-    slru.put(1, 100);
+    slru.put(1, 10, None);
+    slru.put(2, 20, None);
+    slru.put(1, 100, None);
     assert_eq!(slru.len(), 2, "SLRU: update should not increase len");
     assert_eq!(slru.get(&1), Some(&100), "SLRU: value should be updated");
 
     // GDSF - note: get() returns Option<V>, not Option<&V>
     let mut gdsf = make_gdsf(3);
-    gdsf.put(1, 10, 1);
-    gdsf.put(2, 20, 1);
-    gdsf.put(1, 100, 1);
+    gdsf.put(1, 10, Some(1));
+    gdsf.put(2, 20, Some(1));
+    gdsf.put(1, 100, Some(1));
     assert_eq!(gdsf.len(), 2, "GDSF: update should not increase len");
     assert_eq!(gdsf.get(&1), Some(100), "GDSF: value should be updated");
 }
@@ -850,7 +850,7 @@ fn test_all_caches_clear() {
     // LRU
     let mut lru = make_lru(5);
     for i in 0..5 {
-        lru.put(i, i);
+        lru.put(i, i, None);
     }
     lru.clear();
     assert_eq!(lru.len(), 0, "LRU: clear should empty cache");
@@ -862,7 +862,7 @@ fn test_all_caches_clear() {
     // LFU
     let mut lfu = make_lfu(5);
     for i in 0..5 {
-        lfu.put(i, i);
+        lfu.put(i, i, None);
     }
     lfu.clear();
     assert_eq!(lfu.len(), 0, "LFU: clear should empty cache");
@@ -870,7 +870,7 @@ fn test_all_caches_clear() {
     // LFUDA
     let mut lfuda = make_lfuda(5);
     for i in 0..5 {
-        lfuda.put(i, i);
+        lfuda.put(i, i, None);
     }
     lfuda.clear();
     assert_eq!(lfuda.len(), 0, "LFUDA: clear should empty cache");
@@ -878,7 +878,7 @@ fn test_all_caches_clear() {
     // SLRU
     let mut slru = make_slru(5, 2);
     for i in 0..5 {
-        slru.put(i, i);
+        slru.put(i, i, None);
     }
     slru.clear();
     assert_eq!(slru.len(), 0, "SLRU: clear should empty cache");
@@ -886,7 +886,7 @@ fn test_all_caches_clear() {
     // GDSF
     let mut gdsf = make_gdsf(5);
     for i in 0..5 {
-        gdsf.put(i, i, 1);
+        gdsf.put(i, i, Some(1));
     }
     gdsf.clear();
     assert_eq!(gdsf.len(), 0, "GDSF: clear should empty cache");
@@ -909,21 +909,21 @@ fn test_lru_size_tracking() {
     let mut cache = make_lru_with_max_size(100);
 
     // Insert items with sizes
-    cache.put_with_size(1, "a", 30); // size=30, total=30
+    cache.put(1, "a", Some(30)); // size=30, total=30
     assert_eq!(
         cache.current_size(),
         30,
         "Size should be 30 after first insert"
     );
 
-    cache.put_with_size(2, "b", 40); // size=40, total=70
+    cache.put(2, "b", Some(40)); // size=40, total=70
     assert_eq!(
         cache.current_size(),
         70,
         "Size should be 70 after second insert"
     );
 
-    cache.put_with_size(3, "c", 20); // size=20, total=90
+    cache.put(3, "c", Some(20)); // size=20, total=90
     assert_eq!(
         cache.current_size(),
         90,
@@ -942,7 +942,7 @@ fn test_lru_size_tracking_accumulates() {
 
     // Insert multiple items and verify size accumulates
     for i in 0..10 {
-        cache.put_with_size(i, format!("value{}", i), 50);
+        cache.put(i, format!("value{}", i), Some(50));
     }
 
     assert_eq!(
@@ -958,14 +958,14 @@ fn test_lru_entry_count_eviction_updates_size() {
     // Create cache with entry count limit of 3
     let mut cache = make_lru_with_limits(3, 1000);
 
-    cache.put_with_size(1, "a", 30);
-    cache.put_with_size(2, "b", 40);
-    cache.put_with_size(3, "c", 50);
+    cache.put(1, "a", Some(30));
+    cache.put(2, "b", Some(40));
+    cache.put(3, "c", Some(50));
     assert_eq!(cache.current_size(), 120);
     assert_eq!(cache.len(), 3);
 
     // Insert 4th item - triggers count-based eviction of key 1
-    cache.put_with_size(4, "d", 60);
+    cache.put(4, "d", Some(60));
 
     assert!(
         cache.get(&1).is_none(),
@@ -980,9 +980,9 @@ fn test_lru_entry_count_eviction_updates_size() {
 fn test_lfu_size_tracking() {
     let mut cache = make_lfu_with_max_size(1000);
 
-    cache.put_with_size(1, "a", 100);
-    cache.put_with_size(2, "b", 200);
-    cache.put_with_size(3, "c", 150);
+    cache.put(1, "a", Some(100));
+    cache.put(2, "b", Some(200));
+    cache.put(3, "c", Some(150));
 
     assert_eq!(cache.current_size(), 450, "Total size should be 450");
     assert_eq!(cache.len(), 3);
@@ -992,8 +992,8 @@ fn test_lfu_size_tracking() {
 fn test_lfuda_size_tracking() {
     let mut cache = make_lfuda_with_max_size(1000);
 
-    cache.put_with_size(1, "a", 100);
-    cache.put_with_size(2, "b", 200);
+    cache.put(1, "a", Some(100));
+    cache.put(2, "b", Some(200));
 
     assert_eq!(cache.current_size(), 300, "Total size should be 300");
 }
@@ -1002,9 +1002,9 @@ fn test_lfuda_size_tracking() {
 fn test_slru_size_tracking() {
     let mut cache = make_slru_with_max_size(1000);
 
-    cache.put_with_size(1, "a", 100);
-    cache.put_with_size(2, "b", 200);
-    cache.put_with_size(3, "c", 150);
+    cache.put(1, "a", Some(100));
+    cache.put(2, "b", Some(200));
+    cache.put(3, "c", Some(150));
 
     assert_eq!(cache.current_size(), 450, "Total size should be 450");
 }
@@ -1013,8 +1013,8 @@ fn test_slru_size_tracking() {
 fn test_size_reset_on_clear() {
     let mut cache = make_lru_with_max_size(1000);
 
-    cache.put_with_size(1, "a", 30);
-    cache.put_with_size(2, "b", 40);
+    cache.put(1, "a", Some(30));
+    cache.put(2, "b", Some(40));
     assert_eq!(cache.current_size(), 70);
 
     cache.clear();
@@ -1058,16 +1058,16 @@ fn test_lru_capacity_one() {
     // Edge case: cache that can only hold 1 item
     let mut cache = make_lru(1);
 
-    cache.put(1, 10);
+    cache.put(1, 10, None);
     assert_eq!(cache.get(&1), Some(&10));
 
     // Second insert immediately evicts first
-    cache.put(2, 20);
+    cache.put(2, 20, None);
     assert!(cache.get(&1).is_none(), "Key 1 should be evicted");
     assert_eq!(cache.get(&2), Some(&20), "Key 2 should be present");
 
     // Third insert evicts second
-    cache.put(3, 30);
+    cache.put(3, 30, None);
     assert!(cache.get(&2).is_none(), "Key 2 should be evicted");
     assert_eq!(cache.get(&3), Some(&30), "Key 3 should be present");
 }
@@ -1076,17 +1076,17 @@ fn test_lru_capacity_one() {
 fn test_lru_update_moves_to_mru() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
     // LRU order: 1 -> 2 -> 3
 
     // Update key 1 - should move to MRU position
-    cache.put(1, 100);
+    cache.put(1, 100, None);
     // LRU order should now be: 2 -> 3 -> 1
 
     // Insert new key - should evict 2 (now LRU), not 1
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     assert!(
         cache.get(&2).is_none(),
@@ -1107,7 +1107,7 @@ fn test_lru_reverse_access_order() {
 
     // Insert 1, 2, 3, 4, 5
     for i in 1..=5 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
     // LRU order: 1 -> 2 -> 3 -> 4 -> 5
 
@@ -1118,7 +1118,7 @@ fn test_lru_reverse_access_order() {
     // LRU order should now be: 5 -> 4 -> 3 -> 2 -> 1 (reversed)
 
     // Insert new key - should evict 5 (now LRU)
-    cache.put(6, 60);
+    cache.put(6, 60, None);
     assert!(
         cache.get(&5).is_none(),
         "Key 5 should be evicted (was LRU after reverse access)"
@@ -1130,20 +1130,20 @@ fn test_lru_reverse_access_order() {
 fn test_lru_remove_and_reinsert() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Remove middle item
     assert_eq!(cache.remove(&2), Some(20));
     assert_eq!(cache.len(), 2);
 
     // Reinsert - should go to MRU position
-    cache.put(2, 200);
+    cache.put(2, 200, None);
     // LRU order: 1 -> 3 -> 2
 
     // Insert new key - should evict 1
-    cache.put(4, 40);
+    cache.put(4, 40, None);
     assert!(cache.get(&1).is_none(), "Key 1 should be evicted");
     assert_eq!(
         cache.get(&2),
@@ -1163,29 +1163,29 @@ fn test_lfu_all_equal_frequency_fifo() {
     let mut cache = make_lfu(4);
 
     // Insert 4 items - all have freq=1
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // All items have same frequency, FIFO order: 1 -> 2 -> 3 -> 4
 
     // Insert new item - should evict 1 (first in FIFO)
-    cache.put(5, 50);
+    cache.put(5, 50, None);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (FIFO tiebreaker)"
     );
 
     // Insert another - should evict 2 (next in FIFO)
-    cache.put(6, 60);
+    cache.put(6, 60, None);
     assert!(
         cache.get(&2).is_none(),
         "Key 2 should be evicted (FIFO tiebreaker)"
     );
 
     // Insert another - should evict 3
-    cache.put(7, 70);
+    cache.put(7, 70, None);
     assert!(
         cache.get(&3).is_none(),
         "Key 3 should be evicted (FIFO tiebreaker)"
@@ -1197,9 +1197,9 @@ fn test_lfu_new_item_lowest_frequency() {
     // New item has freq=1, could be immediately evicted
     let mut cache = make_lfu(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Access all items many times - they all have high frequency
     for _ in 0..10 {
@@ -1210,12 +1210,12 @@ fn test_lfu_new_item_lowest_frequency() {
     // Frequencies: 1=11, 2=11, 3=11
 
     // Insert new item (freq=1), then another (freq=1)
-    cache.put(4, 40); // Evicts based on FIFO among freq=11 items
+    cache.put(4, 40, None); // Evicts based on FIFO among freq=11 items
     let _first_evicted = (1..=3).find(|&i| cache.get(&i).is_none());
 
     // Insert another - the NEW item (4) has freq=1, much lower than others
     // If freq=1 ties with remaining items at freq=11, FIFO applies
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // Key 4 should be evicted because it has lowest freq (1)
     assert!(
@@ -1229,14 +1229,14 @@ fn test_lfu_new_item_lowest_frequency() {
 fn test_lfu_capacity_one() {
     let mut cache = make_lfu(1);
 
-    cache.put(1, 10);
+    cache.put(1, 10, None);
     // Access many times
     for _ in 0..100 {
         cache.get(&1);
     }
 
     // Even with high frequency, must be evicted when new item comes
-    cache.put(2, 20);
+    cache.put(2, 20, None);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 must be evicted (capacity=1)"
@@ -1248,9 +1248,9 @@ fn test_lfu_capacity_one() {
 fn test_lfu_update_preserves_frequency() {
     let mut cache = make_lfu(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Build up frequency for key 1
     for _ in 0..10 {
@@ -1259,10 +1259,10 @@ fn test_lfu_update_preserves_frequency() {
     // freq: 1=11, 2=1, 3=1
 
     // Update key 1's value - should preserve high frequency
-    cache.put(1, 100);
+    cache.put(1, 100, None);
 
     // Insert new item - should evict 2 or 3 (low freq), NOT key 1
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     assert!(
         cache.get(&1).is_some(),
@@ -1282,19 +1282,19 @@ fn test_slru_all_in_probationary() {
 
     // Insert 5 items, access each only once (no promotion)
     for i in 1..=5 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
     // All items in probationary, LRU order: 1 -> 2 -> 3 -> 4 -> 5
 
     // Insert new item - should evict from probationary (key 1)
-    cache.put(6, 60);
+    cache.put(6, 60, None);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (LRU in probationary)"
     );
 
     // Continue inserting - should keep evicting from probationary
-    cache.put(7, 70);
+    cache.put(7, 70, None);
     assert!(cache.get(&2).is_none(), "Key 2 should be evicted");
 }
 
@@ -1304,8 +1304,8 @@ fn test_slru_protected_full_demotion() {
     let mut cache = make_slru(4, 2);
 
     // Insert and promote 2 items to fill protected
-    cache.put(1, 10);
-    cache.put(2, 20);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
     cache.get(&1); // Access to start promotion
     cache.get(&1); // Second access promotes to protected
     cache.get(&2);
@@ -1313,8 +1313,8 @@ fn test_slru_protected_full_demotion() {
                    // Protected: {1, 2}, Probationary: empty
 
     // Add items to probationary
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
     // Protected: {1, 2}, Probationary: {3, 4}
 
     // Promote key 3 - protected is full, so key 1 (oldest) should be demoted
@@ -1324,7 +1324,7 @@ fn test_slru_protected_full_demotion() {
 
     // Insert new item - should evict from probationary
     // Depending on implementation, either demoted key 1 or key 4 is LRU
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     // Key 2 and 3 should be safe (in protected)
     assert!(cache.get(&2).is_some(), "Key 2 should remain (protected)");
@@ -1335,8 +1335,8 @@ fn test_slru_protected_full_demotion() {
 fn test_slru_access_in_protected_stays() {
     let mut cache = make_slru(4, 2);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
 
     // Promote both to protected
     cache.get(&1);
@@ -1348,8 +1348,8 @@ fn test_slru_access_in_protected_stays() {
     cache.get(&1);
 
     // Add probationary items
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // Promote key 3 - key 2 should be demoted (LRU in protected)
     cache.get(&3);
@@ -1357,7 +1357,7 @@ fn test_slru_access_in_protected_stays() {
 
     // Key 1 should still be in protected (was accessed, moved to MRU)
     // Key 2 should be demoted to probationary
-    cache.put(5, 50);
+    cache.put(5, 50, None);
 
     assert!(
         cache.get(&1).is_some(),
@@ -1376,7 +1376,7 @@ fn test_slru_probationary_larger_than_protected() {
 
     // Fill cache
     for i in 1..=5 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
 
     // Promote only key 5 to protected
@@ -1386,7 +1386,7 @@ fn test_slru_probationary_larger_than_protected() {
 
     // Insert 4 new items - should evict all original probationary items
     for i in 6..=9 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
 
     // Key 5 should survive (protected)
@@ -1407,14 +1407,14 @@ fn test_lfuda_all_equal_priority() {
     let mut cache = make_lfuda(4);
 
     // Insert 4 items - all have same initial priority
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
-    cache.put(4, 40);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
+    cache.put(4, 40, None);
 
     // No accesses - all have equal priority
     // Should use FIFO as tiebreaker
-    cache.put(5, 50);
+    cache.put(5, 50, None);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (FIFO among equal priority)"
@@ -1425,18 +1425,18 @@ fn test_lfuda_all_equal_priority() {
 fn test_lfuda_aging_reduces_priority_gap() {
     let mut cache = make_lfuda(3);
 
-    cache.put(1, 10);
+    cache.put(1, 10, None);
     // Build very high frequency for key 1
     for _ in 0..50 {
         cache.get(&1);
     }
 
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Force multiple evictions to increase global age
     for i in 100..120 {
-        cache.put(i, i);
+        cache.put(i, i, None);
     }
 
     // At this point, high global age means new items have boosted priority
@@ -1448,13 +1448,13 @@ fn test_lfuda_aging_reduces_priority_gap() {
 fn test_lfuda_capacity_one() {
     let mut cache = make_lfuda(1);
 
-    cache.put(1, 10);
+    cache.put(1, 10, None);
     for _ in 0..100 {
         cache.get(&1);
     }
 
     // Must evict even with high priority
-    cache.put(2, 20);
+    cache.put(2, 20, None);
     assert!(
         cache.get(&1).is_none(),
         "Key 1 must be evicted (capacity=1)"
@@ -1473,8 +1473,8 @@ fn test_lfuda_cap_len_is_empty() {
     assert_eq!(cache.len(), 0);
 
     // Add some items
-    cache.put(1, 10);
-    cache.put(2, 20);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
 
     // Test len() and is_empty() with items
     assert!(!cache.is_empty());
@@ -1497,14 +1497,14 @@ fn test_lfuda_current_size_max_size() {
     assert_eq!(cache.current_size(), 0);
 
     // Add items with explicit sizes
-    cache.put_with_size(1, 10, 100);
+    cache.put(1, 10, Some(100));
     assert_eq!(cache.current_size(), 100);
 
-    cache.put_with_size(2, 20, 200);
+    cache.put(2, 20, Some(200));
     assert_eq!(cache.current_size(), 300);
 
     // Update existing key with different size
-    cache.put_with_size(1, 15, 150);
+    cache.put(1, 15, Some(150));
     assert_eq!(cache.current_size(), 350);
 
     // Remove item and verify size decreases
@@ -1524,15 +1524,15 @@ fn test_lfuda_global_age_tracking() {
     assert_eq!(cache.global_age(), 0);
 
     // Fill cache
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Global age should still be 0 (no evictions yet)
     assert_eq!(cache.global_age(), 0);
 
     // Trigger eviction - global age should increase
-    cache.put(4, 40);
+    cache.put(4, 40, None);
     let age_after_first_eviction = cache.global_age();
     // LFUDA sets global age to evicted item's priority (freq + age_at_insertion)
     // Evicted item had priority = 1 + 0 = 1
@@ -1542,7 +1542,7 @@ fn test_lfuda_global_age_tracking() {
     );
 
     // More evictions should continue increasing age
-    cache.put(5, 50);
+    cache.put(5, 50, None);
     let age_after_second = cache.global_age();
     assert!(
         age_after_second >= age_after_first_eviction,
@@ -1575,8 +1575,8 @@ fn test_lfuda_record_miss() {
 fn test_lfuda_get_mut_modifies_value() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(10);
 
-    cache.put("a", 10);
-    cache.put("b", 20);
+    cache.put("a", 10, None);
+    cache.put("b", 20, None);
 
     // Use get_mut to modify value
     if let Some(val) = cache.get_mut(&"a") {
@@ -1594,9 +1594,9 @@ fn test_lfuda_get_mut_modifies_value() {
 fn test_lfuda_get_mut_affects_priority() {
     let mut cache: LfudaCache<i32, i32> = make_lfuda(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Access key 1 via get_mut to increase its priority
     for _ in 0..5 {
@@ -1609,7 +1609,7 @@ fn test_lfuda_get_mut_affects_priority() {
     assert_eq!(cache.get(&1), Some(&15));
 
     // Trigger eviction - key 2 or 3 should be evicted, not key 1
-    cache.put(4, 40);
+    cache.put(4, 40, None);
 
     assert!(
         cache.get(&1).is_some(),
@@ -1622,16 +1622,16 @@ fn test_lfuda_size_eviction_multiple_items() {
     let mut cache: LfudaCache<i32, String> = make_lfuda_with_max_size(100);
 
     // Add several small items
-    cache.put_with_size(1, "a".to_string(), 25);
-    cache.put_with_size(2, "b".to_string(), 25);
-    cache.put_with_size(3, "c".to_string(), 25);
-    cache.put_with_size(4, "d".to_string(), 25);
+    cache.put(1, "a".to_string(), Some(25));
+    cache.put(2, "b".to_string(), Some(25));
+    cache.put(3, "c".to_string(), Some(25));
+    cache.put(4, "d".to_string(), Some(25));
 
     assert_eq!(cache.current_size(), 100);
     assert_eq!(cache.len(), 4);
 
     // Adding a large item should evict multiple small items
-    cache.put_with_size(5, "large".to_string(), 60);
+    cache.put(5, "large".to_string(), Some(60));
 
     // Should have evicted at least 2 items to make room
     assert!(cache.current_size() <= 100);
@@ -1645,7 +1645,7 @@ fn test_lfuda_pop_updates_global_age() {
 
     // Fill cache
     for i in 1..=5 {
-        cache.put(i, i * 10);
+        cache.put(i, i * 10, None);
     }
 
     // Access some items to create priority differences
@@ -1671,12 +1671,12 @@ fn test_lfuda_put_returns_evicted() {
     let mut cache: LfudaCache<i32, i32> = make_lfuda(3);
 
     // Fill cache
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Next put should return evicted item
-    let evicted = cache.put(4, 40);
+    let evicted = cache.put(4, 40, None);
     assert!(evicted.is_some(), "Should return evicted item");
 
     let (key, value) = evicted.unwrap();
@@ -1689,11 +1689,11 @@ fn test_lfuda_put_returns_evicted() {
 fn test_lfuda_update_existing_key() {
     let mut cache: LfudaCache<i32, i32> = make_lfuda(10);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
 
     // Update existing key
-    let old = cache.put(1, 100);
+    let old = cache.put(1, 100, None);
 
     // Should return old value wrapped in tuple
     assert_eq!(old, Some((1, 10)));
@@ -1715,12 +1715,12 @@ fn test_gdsf_all_same_size_and_frequency() {
     let mut cache = make_gdsf(4);
 
     for i in 1..=4 {
-        cache.put(i, i * 10, 10); // All size=10
+        cache.put(i, i * 10, Some(10)); // All size=10
     }
     // All have priority = 1/10 = 0.1
 
     // Should use FIFO as tiebreaker
-    cache.put(5, 50, 10);
+    cache.put(5, 50, Some(10));
     assert!(
         cache.get(&1).is_none(),
         "Key 1 should be evicted (FIFO tiebreaker)"
@@ -1732,17 +1732,17 @@ fn test_gdsf_tiny_vs_huge_size() {
     let mut cache = make_gdsf(3);
 
     // Huge object with moderate frequency
-    cache.put(1, 10, 1000);
+    cache.put(1, 10, Some(1000));
     for _ in 0..10 {
         cache.get(&1); // freq=11, priority = 11/1000 = 0.011
     }
 
     // Tiny objects with low frequency
-    cache.put(2, 20, 1); // freq=1, priority = 1/1 = 1.0
-    cache.put(3, 30, 1); // freq=1, priority = 1/1 = 1.0
+    cache.put(2, 20, Some(1)); // freq=1, priority = 1/1 = 1.0
+    cache.put(3, 30, Some(1)); // freq=1, priority = 1/1 = 1.0
 
     // Insert another - huge object has much lower priority despite more accesses
-    cache.put(4, 40, 1);
+    cache.put(4, 40, Some(1));
 
     assert!(
         cache.get(&1).is_none(),
@@ -1757,9 +1757,9 @@ fn test_gdsf_size_one_equals_lfu() {
     // When all sizes are 1, GDSF should behave like LFU
     let mut cache = make_gdsf(3);
 
-    cache.put(1, 10, 1);
-    cache.put(2, 20, 1);
-    cache.put(3, 30, 1);
+    cache.put(1, 10, Some(1));
+    cache.put(2, 20, Some(1));
+    cache.put(3, 30, Some(1));
 
     // Build frequency for key 1
     for _ in 0..10 {
@@ -1770,7 +1770,7 @@ fn test_gdsf_size_one_equals_lfu() {
     }
     // Priorities (freq/1): 1=11, 2=6, 3=1
 
-    cache.put(4, 40, 1);
+    cache.put(4, 40, Some(1));
     assert!(
         cache.get(&3).is_none(),
         "Key 3 should be evicted (lowest freq when size=1)"
@@ -1782,17 +1782,17 @@ fn test_gdsf_frequency_can_overcome_size() {
     let mut cache = make_gdsf(3);
 
     // Large object with VERY high frequency
-    cache.put(1, 10, 100);
+    cache.put(1, 10, Some(100));
     for _ in 0..500 {
         cache.get(&1); // freq=501, priority = 501/100 = 5.01
     }
 
     // Small objects with low frequency
-    cache.put(2, 20, 1); // freq=1, priority = 1/1 = 1.0
-    cache.put(3, 30, 1); // freq=1, priority = 1/1 = 1.0
+    cache.put(2, 20, Some(1)); // freq=1, priority = 1/1 = 1.0
+    cache.put(3, 30, Some(1)); // freq=1, priority = 1/1 = 1.0
 
     // Insert new - small objects have lower priority
-    cache.put(4, 40, 1);
+    cache.put(4, 40, Some(1));
 
     // Key 2 or 3 should be evicted (priority 1.0 < 5.01)
     assert!(
@@ -1807,12 +1807,12 @@ fn test_gdsf_frequency_can_overcome_size() {
 fn test_gdsf_capacity_one() {
     let mut cache = make_gdsf(1);
 
-    cache.put(1, 10, 1);
+    cache.put(1, 10, Some(1));
     for _ in 0..100 {
         cache.get(&1);
     }
 
-    cache.put(2, 20, 1);
+    cache.put(2, 20, Some(1));
     assert!(
         cache.get(&1).is_none(),
         "Key 1 must be evicted (capacity=1)"
@@ -1842,8 +1842,8 @@ fn test_operations_on_empty_cache() {
 fn test_remove_nonexistent_key() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
 
     // Remove key that doesn't exist
     assert_eq!(cache.remove(&99), None);
@@ -1858,16 +1858,16 @@ fn test_remove_nonexistent_key() {
 fn test_insert_after_clear() {
     let mut cache = make_lru(3);
 
-    cache.put(1, 10);
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(1, 10, None);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     cache.clear();
     assert_eq!(cache.len(), 0);
 
     // Insert after clear - should work normally
-    cache.put(4, 40);
-    cache.put(5, 50);
+    cache.put(4, 40, None);
+    cache.put(5, 50, None);
 
     assert_eq!(cache.len(), 2);
     assert_eq!(cache.get(&4), Some(&40));
@@ -1880,7 +1880,7 @@ fn test_rapid_update_same_key() {
 
     // Insert same key many times
     for i in 0..100 {
-        cache.put(1, i);
+        cache.put(1, i, None);
     }
 
     assert_eq!(cache.len(), 1, "Should only have 1 entry");
@@ -1893,7 +1893,7 @@ fn test_alternating_keys() {
 
     // Alternating pattern that causes continuous eviction
     for i in 0..10 {
-        cache.put(i % 3, i); // Keys 0, 1, 2, 0, 1, 2, ...
+        cache.put(i % 3, i, None); // Keys 0, 1, 2, 0, 1, 2, ...
     }
 
     // Should have the last 2 keys inserted
@@ -1904,18 +1904,18 @@ fn test_alternating_keys() {
 fn test_lfu_get_does_not_exist() {
     let mut cache = make_lfu(3);
 
-    cache.put(1, 10);
+    cache.put(1, 10, None);
 
     // Get non-existent key should not affect frequencies
     assert_eq!(cache.get(&99), None);
     assert_eq!(cache.get(&99), None);
 
-    cache.put(2, 20);
-    cache.put(3, 30);
+    cache.put(2, 20, None);
+    cache.put(3, 30, None);
 
     // Key 1 should still be at freq=1 (only the put)
     // Insert new - all equal freq, FIFO
-    cache.put(4, 40);
+    cache.put(4, 40, None);
     assert!(cache.get(&1).is_none(), "Key 1 should be evicted (FIFO)");
 }
 
@@ -1925,13 +1925,13 @@ fn test_gdsf_zero_size_handling() {
 
     // Size 0 edge case - implementation should handle gracefully
     // (might treat as size 1 or have special handling)
-    cache.put(1, 10, 0);
-    cache.put(2, 20, 1);
-    cache.put(3, 30, 1);
+    cache.put(1, 10, Some(0));
+    cache.put(2, 20, Some(1));
+    cache.put(3, 30, Some(1));
 
     // Should not panic, cache should still function
     assert!(cache.len() <= 3);
-    cache.put(4, 40, 1);
+    cache.put(4, 40, Some(1));
     assert!(cache.len() <= 3);
 }
 
@@ -1952,8 +1952,8 @@ fn test_metrics_size_tracking_no_underflow() {
     let mut cache = make_lru_with_limits(2, 1000);
 
     // Insert items with explicit small sizes
-    cache.put_with_size(1, "a", 1); // Track as 1 byte
-    cache.put_with_size(2, "b", 1); // Track as 1 byte
+    cache.put(1, "a", Some(1)); // Track as 1 byte
+    cache.put(2, "b", Some(1)); // Track as 1 byte
 
     // Current size should be 2
     assert_eq!(cache.current_size(), 2, "Should track 2 bytes");
@@ -1961,7 +1961,7 @@ fn test_metrics_size_tracking_no_underflow() {
     // Insert third item - triggers eviction of key 1
     // On eviction, estimate_object_size() may return a value different from 1
     // This should NOT panic due to subtraction underflow
-    cache.put_with_size(3, "c", 1);
+    cache.put(3, "c", Some(1));
 
     // Cache should still function correctly
     assert_eq!(cache.len(), 2);
@@ -1981,15 +1981,19 @@ fn test_metrics_size_mismatch_on_eviction() {
 
     // Insert items with size=1 but the actual values are larger
     // (estimate_object_size will calculate a bigger size)
-    cache.put_with_size(1, "hello world this is a long string".to_string(), 1);
-    cache.put_with_size(2, "another fairly long string value".to_string(), 1);
-    cache.put_with_size(3, "yet another long string for testing".to_string(), 1);
+    cache.put(1, "hello world this is a long string".to_string(), Some(1));
+    cache.put(2, "another fairly long string value".to_string(), Some(1));
+    cache.put(
+        3,
+        "yet another long string for testing".to_string(),
+        Some(1),
+    );
 
     // Force evictions by inserting more items
     // Each eviction will try to subtract estimate_object_size() from metrics
     // which is larger than the 1 byte we recorded on insertion
     for i in 4..10 {
-        cache.put_with_size(i, format!("value number {}", i), 1);
+        cache.put(i, format!("value number {}", i), Some(1));
     }
 
     // Should not have panicked, and size should be reasonable
@@ -2027,16 +2031,16 @@ fn test_lru_max_size_triggers_eviction() {
     let mut cache: LruCache<String, i32> = make_lru_with_limits(1000, 100);
 
     // Insert items that fit within max_size
-    cache.put_with_size("a".to_string(), 1, 30); // total: 30
-    cache.put_with_size("b".to_string(), 2, 30); // total: 60
-    cache.put_with_size("c".to_string(), 3, 30); // total: 90
+    cache.put("a".to_string(), 1, Some(30)); // total: 30
+    cache.put("b".to_string(), 2, Some(30)); // total: 60
+    cache.put("c".to_string(), 3, Some(30)); // total: 90
 
     assert_eq!(cache.len(), 3, "Should have 3 items");
     assert_eq!(cache.current_size(), 90, "Size should be 90");
 
     // Insert item that would exceed max_size (90 + 20 = 110 > 100)
     // LRU should evict "a" to stay within max_size
-    cache.put_with_size("d".to_string(), 4, 20);
+    cache.put("d".to_string(), 4, Some(20));
 
     // Verify LRU respects max_size
     assert!(
@@ -2071,16 +2075,16 @@ fn test_slru_max_size_triggers_eviction() {
     let mut cache: SlruCache<String, i32> = make_slru_with_limits(1000, 200, 100);
 
     // Insert items that fit within max_size
-    cache.put_with_size("a".to_string(), 1, 30); // total: 30
-    cache.put_with_size("b".to_string(), 2, 30); // total: 60
-    cache.put_with_size("c".to_string(), 3, 30); // total: 90
+    cache.put("a".to_string(), 1, Some(30)); // total: 30
+    cache.put("b".to_string(), 2, Some(30)); // total: 60
+    cache.put("c".to_string(), 3, Some(30)); // total: 90
 
     assert_eq!(cache.len(), 3, "Should have 3 items");
     assert_eq!(cache.current_size(), 90, "Size should be 90");
 
     // Insert item that would exceed max_size (90 + 20 = 110 > 100)
     // SLRU should evict to stay within max_size
-    cache.put_with_size("d".to_string(), 4, 20);
+    cache.put("d".to_string(), 4, Some(20));
 
     assert!(
         cache.current_size() <= 100,
@@ -2094,14 +2098,14 @@ fn test_lfu_max_size_triggers_eviction() {
     // Create LFU with large entry capacity but small max_size
     let mut cache: LfuCache<String, i32> = make_lfu_with_max_size(100);
 
-    cache.put_with_size("a".to_string(), 1, 30);
-    cache.put_with_size("b".to_string(), 2, 30);
-    cache.put_with_size("c".to_string(), 3, 30);
+    cache.put("a".to_string(), 1, Some(30));
+    cache.put("b".to_string(), 2, Some(30));
+    cache.put("c".to_string(), 3, Some(30));
 
     assert_eq!(cache.current_size(), 90);
 
     // Insert item that would exceed max_size
-    cache.put_with_size("d".to_string(), 4, 20);
+    cache.put("d".to_string(), 4, Some(20));
 
     assert!(
         cache.current_size() <= 100,
@@ -2115,14 +2119,14 @@ fn test_lfuda_max_size_triggers_eviction() {
     // Create LFUDA with large entry capacity but small max_size
     let mut cache: LfudaCache<String, i32> = make_lfuda_with_max_size(100);
 
-    cache.put_with_size("a".to_string(), 1, 30);
-    cache.put_with_size("b".to_string(), 2, 30);
-    cache.put_with_size("c".to_string(), 3, 30);
+    cache.put("a".to_string(), 1, Some(30));
+    cache.put("b".to_string(), 2, Some(30));
+    cache.put("c".to_string(), 3, Some(30));
 
     assert_eq!(cache.current_size(), 90);
 
     // Insert item that would exceed max_size
-    cache.put_with_size("d".to_string(), 4, 20);
+    cache.put("d".to_string(), 4, Some(20));
 
     assert!(
         cache.current_size() <= 100,
@@ -2138,14 +2142,14 @@ fn test_slru_max_size_should_evict_multiple_items() {
 
     // Fill with small items
     for i in 0..10 {
-        cache.put_with_size(format!("key{}", i), i, 10); // 10 items × 10 bytes = 100
+        cache.put(format!("key{}", i), i, Some(10)); // 10 items × 10 bytes = 100
     }
 
     assert_eq!(cache.len(), 10);
     assert_eq!(cache.current_size(), 100, "Cache should be at max_size");
 
     // Insert a large item (50 bytes) - should evict multiple small items
-    cache.put_with_size("big".to_string(), 999, 50);
+    cache.put("big".to_string(), 999, Some(50));
 
     // Expected: evict enough items to fit the new 50-byte item
     // Final size should be <= 100
@@ -2166,9 +2170,9 @@ fn test_slru_max_size_should_evict_multiple_items() {
 #[test]
 fn test_lru_get_mut_updates_value() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     // Mutate value through get_mut
     if let Some(v) = cache.get_mut(&"b") {
@@ -2178,7 +2182,7 @@ fn test_lru_get_mut_updates_value() {
 
     // get_mut should update recency like get does
     // "a" is now LRU (we touched "b" via get_mut, then "b" again via get)
-    cache.put("d", 4); // evicts "a"
+    cache.put("d", 4, None); // evicts "a"
     assert!(cache.get(&"a").is_none());
     assert_eq!(cache.get(&"b"), Some(&20));
 }
@@ -2186,9 +2190,9 @@ fn test_lru_get_mut_updates_value() {
 #[test]
 fn test_lfu_get_mut_updates_value() {
     let mut cache: LfuCache<&str, i32> = make_lfu(3);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2199,9 +2203,9 @@ fn test_lfu_get_mut_updates_value() {
 #[test]
 fn test_lfuda_get_mut_updates_value() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(3);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2212,9 +2216,9 @@ fn test_lfuda_get_mut_updates_value() {
 #[test]
 fn test_slru_get_mut_updates_value() {
     let mut cache: SlruCache<&str, i32> = make_slru(5, 2);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2225,9 +2229,9 @@ fn test_slru_get_mut_updates_value() {
 #[test]
 fn test_gdsf_get_mut_updates_value() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
-    cache.put("a", 1, OBJECT_SIZE);
-    cache.put("b", 2, OBJECT_SIZE);
-    cache.put("c", 3, OBJECT_SIZE);
+    cache.put("a", 1, Some(OBJECT_SIZE));
+    cache.put("b", 2, Some(OBJECT_SIZE));
+    cache.put("c", 3, Some(OBJECT_SIZE));
 
     if let Some(v) = cache.get_mut(&"b") {
         *v = 20;
@@ -2247,7 +2251,7 @@ fn test_all_caches_contains() {
     // LRU
     let mut lru: LruCache<&str, i32> = make_lru(3);
     assert!(!lru.contains(&"a"));
-    lru.put("a", 1);
+    lru.put("a", 1, None);
     assert!(lru.contains(&"a"));
     lru.remove(&"a");
     assert!(!lru.contains(&"a"));
@@ -2255,7 +2259,7 @@ fn test_all_caches_contains() {
     // LFU
     let mut lfu: LfuCache<&str, i32> = make_lfu(3);
     assert!(!lfu.contains(&"a"));
-    lfu.put("a", 1);
+    lfu.put("a", 1, None);
     assert!(lfu.contains(&"a"));
     lfu.remove(&"a");
     assert!(!lfu.contains(&"a"));
@@ -2263,7 +2267,7 @@ fn test_all_caches_contains() {
     // LFUDA
     let mut lfuda: LfudaCache<&str, i32> = make_lfuda(3);
     assert!(!lfuda.contains(&"a"));
-    lfuda.put("a", 1);
+    lfuda.put("a", 1, None);
     assert!(lfuda.contains(&"a"));
     lfuda.remove(&"a");
     assert!(!lfuda.contains(&"a"));
@@ -2271,7 +2275,7 @@ fn test_all_caches_contains() {
     // SLRU
     let mut slru: SlruCache<&str, i32> = make_slru(5, 2);
     assert!(!slru.contains(&"a"));
-    slru.put("a", 1);
+    slru.put("a", 1, None);
     assert!(slru.contains(&"a"));
     slru.remove(&"a");
     assert!(!slru.contains(&"a"));
@@ -2279,7 +2283,7 @@ fn test_all_caches_contains() {
     // GDSF
     let mut gdsf: GdsfCache<&str, i32> = make_gdsf(3);
     assert!(!gdsf.contains(&"a"));
-    gdsf.put("a", 1, OBJECT_SIZE);
+    gdsf.put("a", 1, Some(OBJECT_SIZE));
     assert!(gdsf.contains(&"a"));
     gdsf.remove(&"a");
     assert!(!gdsf.contains(&"a"));
@@ -2288,11 +2292,11 @@ fn test_all_caches_contains() {
 #[test]
 fn test_contains_after_eviction() {
     let mut cache: LruCache<&str, i32> = make_lru(2);
-    cache.put("a", 1);
-    cache.put("b", 2);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
     assert!(cache.contains(&"a"));
 
-    cache.put("c", 3); // evicts "a"
+    cache.put("c", 3, None); // evicts "a"
     assert!(!cache.contains(&"a"));
     assert!(cache.contains(&"b"));
     assert!(cache.contains(&"c"));
@@ -2307,15 +2311,15 @@ fn test_contains_after_eviction() {
 #[test]
 fn test_lru_peek_does_not_affect_eviction() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     // Peek at "a" - should NOT update recency
     assert_eq!(cache.peek(&"a"), Some(&1));
 
     // "a" is still LRU despite peek, so it should be evicted
-    cache.put("d", 4);
+    cache.put("d", 4, None);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT prevent eviction of LRU item"
@@ -2325,9 +2329,9 @@ fn test_lru_peek_does_not_affect_eviction() {
 #[test]
 fn test_lfu_peek_does_not_affect_eviction() {
     let mut cache: LfuCache<&str, i32> = make_lfu(3);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     // Access b and c to increase frequency, but only peek at a
     cache.get(&"b");
@@ -2335,7 +2339,7 @@ fn test_lfu_peek_does_not_affect_eviction() {
     assert_eq!(cache.peek(&"a"), Some(&1));
 
     // "a" should still have lowest frequency and be evicted
-    cache.put("d", 4);
+    cache.put("d", 4, None);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT increase frequency"
@@ -2345,15 +2349,15 @@ fn test_lfu_peek_does_not_affect_eviction() {
 #[test]
 fn test_lfuda_peek_does_not_affect_eviction() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(3);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     cache.get(&"b");
     cache.get(&"c");
     assert_eq!(cache.peek(&"a"), Some(&1));
 
-    cache.put("d", 4);
+    cache.put("d", 4, None);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT increase priority in LFUDA"
@@ -2363,17 +2367,17 @@ fn test_lfuda_peek_does_not_affect_eviction() {
 #[test]
 fn test_slru_peek_does_not_affect_eviction() {
     let mut cache: SlruCache<&str, i32> = make_slru(5, 2);
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
-    cache.put("d", 4);
-    cache.put("e", 5);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
+    cache.put("d", 4, None);
+    cache.put("e", 5, None);
 
     // Peek at "a" - should NOT promote to protected
     assert_eq!(cache.peek(&"a"), Some(&1));
 
     // "a" should still be evictable from probationary
-    cache.put("f", 6);
+    cache.put("f", 6, None);
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT promote items in SLRU"
@@ -2383,16 +2387,16 @@ fn test_slru_peek_does_not_affect_eviction() {
 #[test]
 fn test_gdsf_peek_does_not_affect_eviction() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
-    cache.put("a", 1, OBJECT_SIZE);
-    cache.put("b", 2, OBJECT_SIZE);
-    cache.put("c", 3, OBJECT_SIZE);
+    cache.put("a", 1, Some(OBJECT_SIZE));
+    cache.put("b", 2, Some(OBJECT_SIZE));
+    cache.put("c", 3, Some(OBJECT_SIZE));
 
     // Access b and c to increase frequency, but only peek at a
     cache.get(&"b");
     cache.get(&"c");
     assert_eq!(cache.peek(&"a"), Some(&1));
 
-    cache.put("d", 4, OBJECT_SIZE);
+    cache.put("d", 4, Some(OBJECT_SIZE));
     assert!(
         cache.get(&"a").is_none(),
         "peek should NOT increase frequency in GDSF"
@@ -2404,7 +2408,7 @@ fn test_peek_nonexistent_key() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
     assert_eq!(cache.peek(&"missing"), None);
 
-    cache.put("a", 1);
+    cache.put("a", 1, None);
     assert_eq!(cache.peek(&"missing"), None);
     assert_eq!(cache.peek(&"a"), Some(&1));
 }
@@ -2420,9 +2424,9 @@ fn test_lru_pop_returns_lru_item() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
     assert_eq!(cache.pop(), None); // empty cache
 
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     // "a" is LRU
     let popped = cache.pop();
@@ -2436,9 +2440,9 @@ fn test_lfu_pop_returns_least_frequent() {
     let mut cache: LfuCache<&str, i32> = make_lfu(3);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     // Access b and c to increase their frequency
     cache.get(&"b");
@@ -2455,9 +2459,9 @@ fn test_lfuda_pop_returns_lowest_priority() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(3);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     cache.get(&"b");
     cache.get(&"c");
@@ -2472,9 +2476,9 @@ fn test_slru_pop_returns_probationary_item() {
     let mut cache: SlruCache<&str, i32> = make_slru(5, 2);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1);
-    cache.put("b", 2);
-    cache.put("c", 3);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
+    cache.put("c", 3, None);
 
     let popped = cache.pop();
     assert!(popped.is_some());
@@ -2486,9 +2490,9 @@ fn test_gdsf_pop_returns_lowest_priority() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
     assert_eq!(cache.pop(), None);
 
-    cache.put("a", 1, OBJECT_SIZE);
-    cache.put("b", 2, OBJECT_SIZE);
-    cache.put("c", 3, OBJECT_SIZE);
+    cache.put("a", 1, Some(OBJECT_SIZE));
+    cache.put("b", 2, Some(OBJECT_SIZE));
+    cache.put("c", 3, Some(OBJECT_SIZE));
 
     cache.get(&"b");
     cache.get(&"c");
@@ -2528,7 +2532,7 @@ fn test_all_caches_cap() {
 #[test]
 fn test_all_caches_record_miss() {
     let mut lru: LruCache<&str, i32> = make_lru(3);
-    lru.put("a", 1);
+    lru.put("a", 1, None);
     lru.record_miss(100);
     lru.record_miss(200);
     assert_eq!(lru.len(), 1); // cache contents unchanged
@@ -2539,22 +2543,22 @@ fn test_all_caches_record_miss() {
     );
 
     let mut lfu: LfuCache<&str, i32> = make_lfu(3);
-    lfu.put("a", 1);
+    lfu.put("a", 1, None);
     lfu.record_miss(100);
     assert_eq!(lfu.len(), 1);
 
     let mut lfuda: LfudaCache<&str, i32> = make_lfuda(3);
-    lfuda.put("a", 1);
+    lfuda.put("a", 1, None);
     lfuda.record_miss(100);
     assert_eq!(lfuda.len(), 1);
 
     let mut slru: SlruCache<&str, i32> = make_slru(5, 2);
-    slru.put("a", 1);
+    slru.put("a", 1, None);
     slru.record_miss(100);
     assert_eq!(slru.len(), 1);
 
     let mut gdsf: GdsfCache<&str, i32> = make_gdsf(3);
-    gdsf.put("a", 1, OBJECT_SIZE);
+    gdsf.put("a", 1, Some(OBJECT_SIZE));
     gdsf.record_miss(100);
     assert_eq!(gdsf.len(), 1);
 }
@@ -2585,10 +2589,10 @@ fn test_all_caches_algorithm_name() {
 fn test_all_caches_metrics_after_operations() {
     // LRU metrics
     let mut lru: LruCache<&str, i32> = make_lru(2);
-    lru.put("a", 1);
-    lru.put("b", 2);
+    lru.put("a", 1, None);
+    lru.put("b", 2, None);
     lru.get(&"a"); // hit
-    lru.put("c", 3); // eviction
+    lru.put("c", 3, None); // eviction
 
     let metrics = lru.metrics();
     assert!(
@@ -2610,10 +2614,10 @@ fn test_all_caches_metrics_after_operations() {
 
     // LFU metrics
     let mut lfu: LfuCache<&str, i32> = make_lfu(2);
-    lfu.put("a", 1);
-    lfu.put("b", 2);
+    lfu.put("a", 1, None);
+    lfu.put("b", 2, None);
     lfu.get(&"a");
-    lfu.put("c", 3);
+    lfu.put("c", 3, None);
 
     let metrics = lfu.metrics();
     assert!(
@@ -2623,10 +2627,10 @@ fn test_all_caches_metrics_after_operations() {
 
     // LFUDA metrics
     let mut lfuda: LfudaCache<&str, i32> = make_lfuda(2);
-    lfuda.put("a", 1);
-    lfuda.put("b", 2);
+    lfuda.put("a", 1, None);
+    lfuda.put("b", 2, None);
     lfuda.get(&"a");
-    lfuda.put("c", 3);
+    lfuda.put("c", 3, None);
 
     let metrics = lfuda.metrics();
     assert!(
@@ -2636,8 +2640,8 @@ fn test_all_caches_metrics_after_operations() {
 
     // SLRU metrics
     let mut slru: SlruCache<&str, i32> = make_slru(3, 1);
-    slru.put("a", 1);
-    slru.put("b", 2);
+    slru.put("a", 1, None);
+    slru.put("b", 2, None);
     slru.get(&"a");
 
     let metrics = slru.metrics();
@@ -2648,10 +2652,10 @@ fn test_all_caches_metrics_after_operations() {
 
     // GDSF metrics
     let mut gdsf: GdsfCache<&str, i32> = make_gdsf(2);
-    gdsf.put("a", 1, OBJECT_SIZE);
-    gdsf.put("b", 2, OBJECT_SIZE);
+    gdsf.put("a", 1, Some(OBJECT_SIZE));
+    gdsf.put("b", 2, Some(OBJECT_SIZE));
     gdsf.get(&"a");
-    gdsf.put("c", 3, OBJECT_SIZE);
+    gdsf.put("c", 3, Some(OBJECT_SIZE));
 
     let metrics = gdsf.metrics();
     assert!(
@@ -2672,7 +2676,7 @@ fn test_all_caches_metrics_after_operations() {
 #[should_panic(expected = "not yet implemented")]
 fn test_lru_iter_is_unimplemented() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1);
+    cache.put("a", 1, None);
     let _iter = cache.iter();
 }
 
@@ -2680,7 +2684,7 @@ fn test_lru_iter_is_unimplemented() {
 #[should_panic(expected = "not yet implemented")]
 fn test_lru_iter_mut_is_unimplemented() {
     let mut cache: LruCache<&str, i32> = make_lru(3);
-    cache.put("a", 1);
+    cache.put("a", 1, None);
     let _iter = cache.iter_mut();
 }
 
@@ -2693,11 +2697,11 @@ fn test_lfuda_global_age_increases_on_eviction() {
     let mut cache: LfudaCache<&str, i32> = make_lfuda(2);
     assert_eq!(cache.global_age(), 0);
 
-    cache.put("a", 1);
-    cache.put("b", 2);
+    cache.put("a", 1, None);
+    cache.put("b", 2, None);
 
     // Trigger eviction to increase global age
-    cache.put("c", 3);
+    cache.put("c", 3, None);
     // Global age should have increased (set to evicted item's priority)
     // The exact value depends on implementation - we just verify the method works
     let _age_after = cache.global_age();
@@ -2708,11 +2712,11 @@ fn test_gdsf_global_age_increases_on_eviction() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(2);
     assert!((cache.global_age() - 0.0).abs() < f64::EPSILON);
 
-    cache.put("a", 1, OBJECT_SIZE);
-    cache.put("b", 2, OBJECT_SIZE);
+    cache.put("a", 1, Some(OBJECT_SIZE));
+    cache.put("b", 2, Some(OBJECT_SIZE));
 
     // Trigger eviction
-    cache.put("c", 3, OBJECT_SIZE);
+    cache.put("c", 3, Some(OBJECT_SIZE));
     let age_after = cache.global_age();
     assert!(
         age_after >= 0.0,
@@ -2733,9 +2737,9 @@ fn test_slru_protected_max_size() {
 #[allow(deprecated)]
 fn test_gdsf_pop_key() {
     let mut cache: GdsfCache<&str, i32> = make_gdsf(3);
-    cache.put("a", 1, OBJECT_SIZE);
-    cache.put("b", 2, OBJECT_SIZE);
-    cache.put("c", 3, OBJECT_SIZE);
+    cache.put("a", 1, Some(OBJECT_SIZE));
+    cache.put("b", 2, Some(OBJECT_SIZE));
+    cache.put("c", 3, Some(OBJECT_SIZE));
 
     // pop_key removes a specific key
     let removed = cache.pop_key(&"b");

--- a/tests/no_std_tests.rs
+++ b/tests/no_std_tests.rs
@@ -71,15 +71,15 @@ fn test_lru_in_no_std() {
     let key2 = String::from("key2");
     let key3 = String::from("key3");
 
-    cache.put(key1.clone(), 1, None);
-    cache.put(key2.clone(), 2, None);
+    cache.put(key1.clone(), 1, 1);
+    cache.put(key2.clone(), 2, 1);
 
     // Check if keys are present
     assert_eq!(*cache.get(&key1).unwrap(), 1);
     assert_eq!(*cache.get(&key2).unwrap(), 2);
 
     // This should evict key1
-    cache.put(key3.clone(), 3, None);
+    cache.put(key3.clone(), 3, 1);
 
     assert!(cache.get(&key1).is_none());
     assert_eq!(*cache.get(&key2).unwrap(), 2);
@@ -93,8 +93,8 @@ fn test_lfu_in_no_std() {
     let key1 = String::from("key1");
     let key2 = String::from("key2");
 
-    cache.put(key1.clone(), 1, None);
-    cache.put(key2.clone(), 2, None);
+    cache.put(key1.clone(), 1, 1);
+    cache.put(key2.clone(), 2, 1);
 
     // Access key1 multiple times to increase its frequency
     cache.get(&key1);
@@ -102,7 +102,7 @@ fn test_lfu_in_no_std() {
 
     // Add a new item, which should evict key2 (lower frequency)
     let key3 = String::from("key3");
-    cache.put(key3.clone(), 3, None);
+    cache.put(key3.clone(), 3, 1);
 
     assert_eq!(*cache.get(&key1).unwrap(), 1);
     assert!(cache.get(&key2).is_none());
@@ -116,15 +116,15 @@ fn test_lfuda_in_no_std() {
     let key1 = String::from("key1");
     let key2 = String::from("key2");
 
-    cache.put(key1.clone(), 1, None);
-    cache.put(key2.clone(), 2, None);
+    cache.put(key1.clone(), 1, 1);
+    cache.put(key2.clone(), 2, 1);
 
     // Access key1 to increase its frequency
     cache.get(&key1);
 
     // Add a new key which should evict key2
     let key3 = String::from("key3");
-    cache.put(key3.clone(), 3, None);
+    cache.put(key3.clone(), 3, 1);
 
     assert_eq!(*cache.get(&key1).unwrap(), 1);
     assert!(cache.get(&key2).is_none());
@@ -139,14 +139,14 @@ fn test_slru_in_no_std() {
 
     // Add 4 items to fill the cache
     for (i, key) in keys.iter().enumerate().take(4) {
-        cache.put(key.clone(), i, None);
+        cache.put(key.clone(), i, 1);
     }
 
     // Access the first key to promote it to protected segment
     cache.get(&keys[0]);
 
     // Add a new item which should evict from probationary segment
-    cache.put(keys[4].clone(), 4, None);
+    cache.put(keys[4].clone(), 4, 1);
 
     // The first key should still be in the cache (protected)
     assert_eq!(*cache.get(&keys[0]).unwrap(), 0);
@@ -176,8 +176,8 @@ fn test_gdsf_in_no_std() {
     let key1 = String::from("key1");
     let key2 = String::from("key2");
 
-    cache.put(key1.clone(), "value1", Some(30));
-    cache.put(key2.clone(), "value2", Some(50));
+    cache.put(key1.clone(), "value1", 30);
+    cache.put(key2.clone(), "value2", 50);
 
     // Verify we can retrieve the items - GDSF get() returns values, not references
     assert_eq!(cache.get(&key1), Some("value1"));
@@ -190,7 +190,7 @@ fn test_gdsf_in_no_std() {
     cache.get(&key1);
 
     // Add a third item, which will cause an eviction if the total size exceeds capacity
-    cache.put(key3.clone(), "value3", Some(40));
+    cache.put(key3.clone(), "value3", 40);
 
     // Verify we can still access at least one of the items
     assert!(cache.get(&key1).is_some() || cache.get(&key2).is_some() || cache.get(&key3).is_some());
@@ -213,8 +213,8 @@ fn test_complex_types_in_no_std() {
     let key2 = Vec::<u8>::from([4, 5, 6]);
     let value2 = Vec::<i32>::from([40, 50, 60]);
 
-    cache.put(key1.clone(), value1.clone(), None);
-    cache.put(key2.clone(), value2.clone(), None);
+    cache.put(key1.clone(), value1.clone(), 1);
+    cache.put(key2.clone(), value2.clone(), 1);
 
     assert_eq!(*cache.get(&key1).unwrap(), value1);
     assert_eq!(*cache.get(&key2).unwrap(), value2);

--- a/tests/no_std_tests.rs
+++ b/tests/no_std_tests.rs
@@ -71,15 +71,15 @@ fn test_lru_in_no_std() {
     let key2 = String::from("key2");
     let key3 = String::from("key3");
 
-    cache.put(key1.clone(), 1);
-    cache.put(key2.clone(), 2);
+    cache.put(key1.clone(), 1, None);
+    cache.put(key2.clone(), 2, None);
 
     // Check if keys are present
     assert_eq!(*cache.get(&key1).unwrap(), 1);
     assert_eq!(*cache.get(&key2).unwrap(), 2);
 
     // This should evict key1
-    cache.put(key3.clone(), 3);
+    cache.put(key3.clone(), 3, None);
 
     assert!(cache.get(&key1).is_none());
     assert_eq!(*cache.get(&key2).unwrap(), 2);
@@ -93,8 +93,8 @@ fn test_lfu_in_no_std() {
     let key1 = String::from("key1");
     let key2 = String::from("key2");
 
-    cache.put(key1.clone(), 1);
-    cache.put(key2.clone(), 2);
+    cache.put(key1.clone(), 1, None);
+    cache.put(key2.clone(), 2, None);
 
     // Access key1 multiple times to increase its frequency
     cache.get(&key1);
@@ -102,7 +102,7 @@ fn test_lfu_in_no_std() {
 
     // Add a new item, which should evict key2 (lower frequency)
     let key3 = String::from("key3");
-    cache.put(key3.clone(), 3);
+    cache.put(key3.clone(), 3, None);
 
     assert_eq!(*cache.get(&key1).unwrap(), 1);
     assert!(cache.get(&key2).is_none());
@@ -116,15 +116,15 @@ fn test_lfuda_in_no_std() {
     let key1 = String::from("key1");
     let key2 = String::from("key2");
 
-    cache.put(key1.clone(), 1);
-    cache.put(key2.clone(), 2);
+    cache.put(key1.clone(), 1, None);
+    cache.put(key2.clone(), 2, None);
 
     // Access key1 to increase its frequency
     cache.get(&key1);
 
     // Add a new key which should evict key2
     let key3 = String::from("key3");
-    cache.put(key3.clone(), 3);
+    cache.put(key3.clone(), 3, None);
 
     assert_eq!(*cache.get(&key1).unwrap(), 1);
     assert!(cache.get(&key2).is_none());
@@ -139,14 +139,14 @@ fn test_slru_in_no_std() {
 
     // Add 4 items to fill the cache
     for (i, key) in keys.iter().enumerate().take(4) {
-        cache.put(key.clone(), i);
+        cache.put(key.clone(), i, None);
     }
 
     // Access the first key to promote it to protected segment
     cache.get(&keys[0]);
 
     // Add a new item which should evict from probationary segment
-    cache.put(keys[4].clone(), 4);
+    cache.put(keys[4].clone(), 4, None);
 
     // The first key should still be in the cache (protected)
     assert_eq!(*cache.get(&keys[0]).unwrap(), 0);
@@ -176,8 +176,8 @@ fn test_gdsf_in_no_std() {
     let key1 = String::from("key1");
     let key2 = String::from("key2");
 
-    cache.put(key1.clone(), "value1", 30);
-    cache.put(key2.clone(), "value2", 50);
+    cache.put(key1.clone(), "value1", Some(30));
+    cache.put(key2.clone(), "value2", Some(50));
 
     // Verify we can retrieve the items - GDSF get() returns values, not references
     assert_eq!(cache.get(&key1), Some("value1"));
@@ -190,7 +190,7 @@ fn test_gdsf_in_no_std() {
     cache.get(&key1);
 
     // Add a third item, which will cause an eviction if the total size exceeds capacity
-    cache.put(key3.clone(), "value3", 40);
+    cache.put(key3.clone(), "value3", Some(40));
 
     // Verify we can still access at least one of the items
     assert!(cache.get(&key1).is_some() || cache.get(&key2).is_some() || cache.get(&key3).is_some());
@@ -213,8 +213,8 @@ fn test_complex_types_in_no_std() {
     let key2 = Vec::<u8>::from([4, 5, 6]);
     let value2 = Vec::<i32>::from([40, 50, 60]);
 
-    cache.put(key1.clone(), value1.clone());
-    cache.put(key2.clone(), value2.clone());
+    cache.put(key1.clone(), value1.clone(), None);
+    cache.put(key2.clone(), value2.clone(), None);
 
     assert_eq!(*cache.get(&key1).unwrap(), value1);
     assert_eq!(*cache.get(&key2).unwrap(), value2);


### PR DESCRIPTION
BREAKING CHANGE: The put method signature changed for all cache algorithms.
The separate put_with_size() method has been removed.

Before:
  cache.put(key, value);
  cache.put_with_size(key, value, size);

After:
  cache.put(key, value, None);        // size defaults to 1
  cache.put(key, value, Some(size));  // explicit size

Changes:
- Unified put API across all 5 algorithms (LRU, LFU, LFUDA, SLRU, GDSF)
- Updated all concurrent cache variants
- Updated cache-simulator to use unified API
- Consolidated put_with_size_stats into put_stats
- Removed estimate_object_size() helper functions
- Updated all tests, examples, and documentation"
